### PR TITLE
Fix action syntax error

### DIFF
--- a/.github/actions/build-and-push-to-quay/action.yml
+++ b/.github/actions/build-and-push-to-quay/action.yml
@@ -61,7 +61,7 @@ runs:
 
         cd ${{ inputs.docker_directory }}
 
-        if [ "${{ inputs.tag_cargo_version_if_present }}" == "true" ] && [ test -f "Cargo.toml" ]; then
+        if [ "${{ inputs.tag_cargo_version_if_present }}" == "true" ] && test -f "Cargo.toml"; then
             echo "Cargo file detected, adding to tags"
             VERSION=$(stoml Cargo.toml package.version)
             TAGS="$TAGS $VERSION"

--- a/postgres/coredb-pg-base/Cargo.toml
+++ b/postgres/coredb-pg-base/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "coredb-pg-base"
-version = "15.3.0-coredb-pg-base.3"
+version = "15.3.0-coredb-pg-base.4"
 edition = "2021"
-authors = ["CoreDB.io"]
+authors = ["tembo.io"]
 description = "Base image for CoreDB's distribution of postgres"
-homepage = "https://www.coredb.io"
+homepage = "https://www.tembo.io"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+repository = "https://github.com/tembo-io/tembo/tree/main/postgres"
 publish = false
 
 

--- a/postgres/coredb-pg-base/Cargo.toml
+++ b/postgres/coredb-pg-base/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://www.coredb.io"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+publish = false
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://www.coredb.io"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+publish = false
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.14"
+version = "15.2.0-coredb-pg-slim.15"
 edition = "2021"
-authors = ["CoreDB.io"]
+authors = ["tembo.io"]
 description = "CoreDB distribution of postgres"
-homepage = "https://www.coredb.io"
+homepage = "https://www.tembo.io"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+repository = "https://github.com/tembo-io/tembo/tree/main/postgres"
 publish = false
 
 

--- a/postgres/coredb-pg/Cargo.toml
+++ b/postgres/coredb-pg/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://www.coredb.io"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+publish = false
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/postgres/coredb-pg/Cargo.toml
+++ b/postgres/coredb-pg/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "coredb-pg"
-version = "15.2.0-coredb-pg.5"
+version = "15.2.0-coredb-pg.6"
 edition = "2021"
-authors = ["CoreDB.io"]
-description = "CoreDB distribution of postgres"
-homepage = "https://www.coredb.io"
+authors = ["tembo.io"]
+description = "Tembo distribution of postgres"
+homepage = "https://www.tembo.io"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+repository = "https://github.com/tembo-io/tembo/tree/main/postgres"
 publish = false
 
 

--- a/postgres/tembo-pg-cnpg/Cargo.toml
+++ b/postgres/tembo-pg-cnpg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-pg-cnpg"
-version = "15.3.0-tembo-pg-cnpg.1"
+version = "15.3-1"
 edition = "2021"
 authors = ["CoreDB.io"]
 description = "Container image for Tembo's distribution of postgres"

--- a/postgres/tembo-pg-cnpg/Cargo.toml
+++ b/postgres/tembo-pg-cnpg/Cargo.toml
@@ -2,12 +2,13 @@
 name = "tembo-pg-cnpg"
 version = "15.3-1"
 edition = "2021"
-authors = ["CoreDB.io"]
+authors = ["tembo.io"]
 description = "Container image for Tembo's distribution of postgres"
-homepage = "https://www.coredb.io"
+homepage = "https://www.tembo.io"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/CoreDB-io/coredb/tree/main/postgres"
+repository = "https://github.com/tembo-io/tembo/tree/main/postgres"
+publish = false
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/postgres/tembo-pg-cnpg/Cargo.toml
+++ b/postgres/tembo-pg-cnpg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-pg-cnpg"
-version = "15.3-1"
+version = "15.3.0-1"
 edition = "2021"
 authors = ["tembo.io"]
 description = "Container image for Tembo's distribution of postgres"

--- a/postgres/tembo-pg-cnpg/Dockerfile
+++ b/postgres/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.6.0
+ARG TRUNK_VER=0.6.1
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk


### PR DESCRIPTION
The action that we are using to build and push images to quay.io has a syntax error when we try to figure out if we want to tag the version listed in the `Cargo.toml`

* Fix syntax error in action
* Bump trunk cli in CNPG image
* Start using a realistic version in the CNPG image `Cargo.toml`
* Do not publish the container image versions to [crates.io](https://crates.io)

fixes: [TEM-1194](https://linear.app/tembo/issue/TEM-1194/tag-tembo-cnpg-images-using-cargo-version)