### PR TITLE
add modified hba conf file to allow for migration to cnpg

### DIFF
--- a/postgres/coredb-pg-slim/Cargo.toml
+++ b/postgres/coredb-pg-slim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coredb-pg-slim"
-version = "15.2.0-coredb-pg-slim.15"
+version = "15.3.0-coredb-pg-slim.1"
 edition = "2021"
 authors = ["tembo.io"]
 description = "CoreDB distribution of postgres"

--- a/postgres/coredb-pg-slim/Dockerfile
+++ b/postgres/coredb-pg-slim/Dockerfile
@@ -68,6 +68,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY ./postgresql.conf /usr/share/postgresql/${PG_MAJOR}/postgresql.conf.sample
 COPY ./postgresql.conf /postgresql.conf.replace
+COPY ./pg_hba.conf /usr/share/postgresql/${PG_MAJOR}/pg_hba.conf.sample
+COPY ./pg_hba.conf /pg_hba.conf.replace
 
 WORKDIR /git
 RUN git clone --branch "v${PG_VECTOR_VER}" https://github.com/pgvector/pgvector.git

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -361,7 +361,7 @@ _main() {
 
 			# ensure we copy the lastest configuration over
 			update_postgresql_conf
-      update_hba_conf
+			update_hba_conf
 
 
 			docker_temp_server_stop
@@ -373,7 +373,7 @@ _main() {
 		else
 			# ensure we copy the lastest configuration over
 			update_postgresql_conf
-      update_hba_conf
+			update_hba_conf
 			cat <<-'EOM'
 				PostgreSQL Database directory appears to contain a database; Skipping initialization
 			EOM

--- a/postgres/coredb-pg-slim/docker-entrypoint.sh
+++ b/postgres/coredb-pg-slim/docker-entrypoint.sh
@@ -266,6 +266,26 @@ update_postgresql_conf() {
     fi
 }
 
+# Make sure we always copy the correct pg_hba.conf, even if it already exists
+# If pg_hba.conf.replace is newer, we copy that to $PGDATA/pg_hba.conf
+update_hba_conf() {
+    # Define the path to the replacement file
+    local replace_file="/pg_hba.conf.replace"
+
+    # Check if the replacement file exists
+    if [ -f "$replace_file" ]; then
+        # If the replacement file and the current postgresql.conf file are different, replace postgresql.conf
+        if ! cmp -s "$PGDATA/pg_hba.conf" "$replace_file"; then
+            echo "pg_hba.conf is different from the replacement, updating..."
+            cp "$replace_file" "$PGDATA/pg_hba.conf"
+        else
+            echo "pg_hba.conf is the same as the replacement, no update needed."
+        fi
+    else
+        echo "No replacement file found, skipping update."
+    fi
+}
+
 # start socket-only postgresql server for setting up or running scripts
 # all arguments will be passed along as arguments to `postgres` (via pg_ctl)
 docker_temp_server_start() {
@@ -341,6 +361,7 @@ _main() {
 
 			# ensure we copy the lastest configuration over
 			update_postgresql_conf
+      update_hba_conf
 
 
 			docker_temp_server_stop
@@ -352,6 +373,7 @@ _main() {
 		else
 			# ensure we copy the lastest configuration over
 			update_postgresql_conf
+      update_hba_conf
 			cat <<-'EOM'
 				PostgreSQL Database directory appears to contain a database; Skipping initialization
 			EOM

--- a/postgres/coredb-pg-slim/pg_hba.conf
+++ b/postgres/coredb-pg-slim/pg_hba.conf
@@ -1,0 +1,11 @@
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
+local   replication     all                                     trust
+host    replication     all             127.0.0.1/32            trust
+host    replication     all             ::1/128                 trust
+
+host    all             all             all                     scram-sha-256
+host    replication     postgres        all                     md5
+host    all             postgres        all                     md5


### PR DESCRIPTION
Copy in modified `pg_hba.conf` file into the now old CoreDB image.  This will allow us to bootstrap CNPG instances from the old CoreDB instances using automation inside CNPG.

fixes: [TEM-1192](https://linear.app/tembo/issue/TEM-1192/hba-conf-in-coredb-for-replication)