### PR TITLE
add actions to update the pod-init image in ArgoCD

### DIFF
--- a/.github/actions/build-and-push-to-quay/action.yml
+++ b/.github/actions/build-and-push-to-quay/action.yml
@@ -68,12 +68,13 @@ runs:
 
         # input tags
         TAGS='${{ inputs.tags }}'
+        SHORT_SHA=$(git rev-parse --short HEAD)
 
         cd ${{ inputs.docker_directory }}
 
         if [ "${{ inputs.tag_cargo_version_if_present }}" == "true" ] && test -f "Cargo.toml"; then
             echo "Cargo file detected, adding to tags"
-            VERSION=$(stoml Cargo.toml package.version)
+            VERSION=$(stoml Cargo.toml package.version)-${SHORT_SHA}
             TAGS="$TAGS $VERSION"
         fi
 
@@ -91,7 +92,6 @@ runs:
         fi
 
         # Short Git hash
-        SHORT_SHA=$(git rev-parse --short HEAD)
         TAGS="$TAGS ${SHORT_SHA}"
 
         echo "TAGS=$TAGS" >> $GITHUB_OUTPUT

--- a/.github/actions/update-pod-init/action.yaml
+++ b/.github/actions/update-pod-init/action.yaml
@@ -1,0 +1,53 @@
+name: 'Argo CD update for tembo-pod-init'
+description: 'Push changes to a branch in ArgoCD'
+inputs:
+  repository:
+    description: 'The ArgoCD repository'
+    required: true
+  ssh_key:
+    description: 'The SSH key for the repository'
+    required: true
+  branch:
+    description: 'The branch to update'
+    required: true
+  version:
+    description: 'The version to use for updating'
+    required: true
+  subdirectory:
+    description: 'The subdirectory to update'
+    required: true
+  clone_into:
+    description: 'The directory to clone the argocd repo into'
+    default: 'argocd-repo'
+    required: false
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+  - name: Check out the repo
+    uses: actions/checkout@v3
+    with:
+      repository: ${{ inputs.repository }}
+      ssh-key: ${{ inputs.ssh_key }}
+      path: ${{ inputs.clone_into }}
+  - name: Git commit and push to remote
+    shell: bash
+    run: |
+      set -xe
+      cd ${{ inputs.clone_into }}
+      git config --global user.name "coredb-service-user"
+      git config --global user.email "admin+github@coredb.io"
+      git fetch origin ${{ inputs.branch }} && git checkout ${{ inputs.branch }} || git checkout -b ${{ inputs.branch }}
+  - name: image version
+    uses: mikefarah/yq@v4.34.1
+    with:
+      cmd: yq -i '(.spec.source.helm.parameters.[] | select(.name == "initContainerImage.tag")).value = "${{ inputs.version }}"' ${{ inputs.clone_into }}/${{ inputs.subdirectory }}/tembo-pod-init.yaml
+  - name: Git commit and push to remote
+    shell: bash
+    run: |
+      set -xe
+      cd ${{ inputs.clone_into }}
+      git add --all
+      # debugging
+      git diff HEAD
+      git diff --staged --quiet && echo "No changes to commit" || (git commit -m "Update from tembo-io/tembo-pod-init: ${{ inputs.version }}" && git push origin ${{ inputs.branch }})

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -83,3 +83,36 @@ jobs:
           quay_user_tembo: ${{ secrets.QUAY_USER_TEMBO }}
           quay_password_tembo: ${{ secrets.QUAY_PASSWORD_TEMBO }}
 
+  pod_init_argocd_update:
+    name: ArgoCD update automation for tembo-pod-init
+    needs:
+      - find_directories
+      - build_and_push_images
+    if: ${{ github.ref == 'refs/heads/main' }} 
+    runs-on: ubuntu-20.04
+    strategy:
+      # fail-fast means to cancel all jobs if one fails
+      fail-fast: false
+      matrix:
+        include:
+          - repository: tembo-io/app-deploy-dev
+            subdirectory: dev
+            branch: main
+          - repository: tembo-io/app-deploy
+            subdirectory: staging
+            branch: staging-updates
+          - repository: tembo-io/app-deploy
+            subdirectory: prod
+            branch: prod-updates
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+      - name: Update ArcgoCD Deployment for tembo-pod-init
+        uses: ./.github/actions/update-pod-init
+        with:
+          repository: ${{ matrix.repository }}
+          ssh_key: ${{ secrets.SERVICE_USER_GITHUB_SSH_KEY }}
+          branch: ${{ matrix.branch }}
+          version: ${{ needs.find_directories.outputs.short_sha }}
+          subdirectory: ${{ matrix.subdirectory }}
+


### PR DESCRIPTION
Adding GH Actions automation to automatically update the ArgoCD `Application` initContainerImage tag for `tembo-pod-init`

Also when we tag with the version listed in the `Cargo.toml`, append the short git SHA to the tag.