### PR TITLE
[TEM-1192] bump slim image for messaging stack image

### DIFF
--- a/postgres/messaging/Dockerfile
+++ b/postgres/messaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/coredb/coredb-pg-slim:370c253
+FROM quay.io/coredb/coredb-pg-slim:f57e860
 
 USER root
 


### PR DESCRIPTION
Update messaging image to use latest `coredb-pg-slim` image from #373 