### PR TITLE
Allow further use cases for find-changed-directories workflow

### DIFF
--- a/.github/actions/find-changed-directories/action.yml
+++ b/.github/actions/find-changed-directories/action.yml
@@ -4,8 +4,12 @@ inputs:
   contains_the_file:
     description: 'Look for directories with this file in the root of that directory. For example, Dockerfile or Cargo.toml'
     required: true
-  changed_relative_to_branch:
-    description: 'The branch on the origin to compare with to determine if this directory has changed. For example "main".'
+  fetch_branch_to_compare:
+    description: 'The branch to fetch when looking to compare a ref, typically main'
+    default: "main"
+    required: true
+  changed_relative_to_ref:
+    description: 'The ref on the fetched branch to compare with to determine if this directory has changed. For example "origin/main" or a git commit hash.'
     required: true
   ignore_dirs:
     description: A list of directories to ignore.
@@ -23,7 +27,7 @@ runs:
       id: find_directories
       run: |
         set -xe
-        git fetch origin ${{ inputs.changed_relative_to_branch }} || true
+        git fetch origin ${{ inputs.fetch_branch_to_compare }} || true
         # Get directories with a Dockerfile that have not changed
         # relative to the branch we are pulling into
         echo "${{inputs.ignore_dirs}}"
@@ -37,7 +41,7 @@ runs:
           # This will check if the directory has changed relative to the branch we are PRing
           # into, and if it's not a PR, in the case of main or release/**, then it will
           # build all docker directories
-          if git diff --quiet HEAD origin/${{ inputs.changed_relative_to_branch }} -- "$dir"; then
+          if git diff --quiet HEAD ${{ inputs.changed_relative_to_ref }} -- "$dir"; then
             echo ""
           else
             echo "$dir"

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -29,7 +29,7 @@ jobs:
           # This allows for filtering out unchanged directories
           # in a pull request, and using all directories on the release
           # or main branches.
-          changed_relative_to_branch: ${{ github.base_ref || 'not-a-branch' }}
+          changed_relative_to_ref: origin/${{ github.base_ref || 'not-a-branch' }}
 
 
   cargo_publish:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'release/[0-9]+.[0-9]+'
 
 jobs:
   find_directories:
@@ -33,7 +32,7 @@ jobs:
           # This allows for filtering out unchanged directories
           # in a pull request, and using all directories on the release
           # or main branches.
-          changed_relative_to_branch: ${{ github.base_ref || 'not-a-branch' }}
+          changed_relative_to_ref: origin/${{ github.base_ref || 'not-a-branch' }}
 
 
   build_and_push_images:
@@ -88,7 +87,7 @@ jobs:
     needs:
       - find_directories
       - build_and_push_images
-    if: ${{ github.ref == 'refs/heads/main' }} 
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-20.04
     strategy:
       # fail-fast means to cancel all jobs if one fails
@@ -115,4 +114,3 @@ jobs:
           branch: ${{ matrix.branch }}
           version: ${{ needs.find_directories.outputs.short_sha }}
           subdirectory: ${{ matrix.subdirectory }}
-


### PR DESCRIPTION
This change allows using the workflow to find changed directories on main branch, triggering a matrix build for all changed directories after a merge to main. This works because the workflow caller can ask for the diff between the current commit and previous commit in the case of running on the main branch. Currently, the diff only works for the diff between different branches.