### PR TITLE
update trunk, pre install pg_stat_statements

### DIFF
--- a/postgres/tembo-pg-cnpg/Cargo.toml
+++ b/postgres/tembo-pg-cnpg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-pg-cnpg"
-version = "15.3.0-1"
+version = "15.3.0-2"
 edition = "2021"
 authors = ["tembo.io"]
 description = "Container image for Tembo's distribution of postgres"

--- a/postgres/tembo-pg-cnpg/Dockerfile
+++ b/postgres/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.9.0
+ARG TRUNK_VER=0.8.0
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk

--- a/postgres/tembo-pg-cnpg/Dockerfile
+++ b/postgres/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.6.1
+ARG TRUNK_VER=0.9.0
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk
@@ -26,6 +26,9 @@ RUN set -xe; \
   apt-get autoremove -y; \
   apt-get clean; \
 	rm -rf /var/lib/apt/lists/*;
+
+# Install pg_stat_statements
+RUN trunk install pg_stat_statements
 
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres


### PR DESCRIPTION
Add `pg_stat_statements` to the default CNPG image and bump trunk to latest CLI version.