### PR TITLE
ensure we copy over pg_stat_statement

### DIFF
--- a/postgres/tembo-pg-cnpg/Cargo.toml
+++ b/postgres/tembo-pg-cnpg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-pg-cnpg"
-version = "15.3.0-2"
+version = "15.3.0-3"
 edition = "2021"
 authors = ["tembo.io"]
 description = "Container image for Tembo's distribution of postgres"

--- a/postgres/tembo-pg-cnpg/Dockerfile
+++ b/postgres/tembo-pg-cnpg/Dockerfile
@@ -30,6 +30,11 @@ RUN set -xe; \
 # Install pg_stat_statements
 RUN trunk install pg_stat_statements
 
+# cache pg_stat_statements to temp directory
+RUN set -eux; \
+      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
+      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
+
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres
 USER 26


### PR DESCRIPTION
Just installing `pg_stat_statements` will not work with CNPG.  We must follow the same pattern we have in `coredb-pg-base` image to make sure all extensions and libraries are copied to the correct locations.