### PR TITLE
Bump helm chart version fro CRD updates

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -29,11 +29,38 @@ jobs:
           changed_relative_to_branch: ${{ github.base_ref || 'not-a-branch' }}
           ignore_dirs: ".tembo"
 
+  # We can check versions using ct, but there is a bug checking 1 chart. So lets
+  # just do it this way for now.
+  # https://github.com/helm/chart-testing/pull/594
+  check_version:
+    name: Check Helm chart version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          path: 'code'
+
+      - name: Fetch main branch
+        run: git fetch origin main:main
+
+      - name: Check chart version
+        run: |
+          CURR_VERSION=$(cat code/charts/tembo-operator/Chart.yaml | grep version: | cut -d ' ' -f 2)
+          MAIN_VERSION=$(git show main:charts/tembo-operator/Chart.yaml | grep version: | cut -d ' ' -f 2)
+
+          if [ "$CURR_VERSION" = "$MAIN_VERSION" ]; then
+            echo "Helm chart version needs to be bumped!"
+            exit 1
+          fi
+
   lint:
     name: Lint charts
     runs-on: ubuntu-latest
     needs:
       - find_directories
+      - check_version
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_directories.outputs.directories) }}
@@ -51,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - find_directories
+      - check_version
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: 'Helm chart to deploy the tembo-operator'
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.2.0
+version: 0.2.1
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo-stacks

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,13 +1,16 @@
-Remote: origin
-TargetBranch: main
-CheckVersionIncrement: true
-ProcessAllCharts: false
-Charts: [charts/tembo-operator]
-ChartRepos: [cloudnative-pg=https://cloudnative-pg.github.io/charts]
-ChartDirs: [charts]
-HelmExtraArgs: --timeout 10m
-Debug: false
-KubectlTimeout: 0s
-PrintLogs: true
+remote: origin
+target-branch: main
+check-version-infrement: true
+process-all-charts: false
+charts:
+  - charts/tembo-operator
+chart-repos:
+  - cloudnative-pg=https://cloudnative-pg.github.io/charts
+chart-dirs:
+  - charts
+helm-extra-args: --timeout 10m
+debug: false
+kubectl-timeout: 0s
+print-logs: true
 # Disable upgrade testing due to CNPG CRD annotation "helm.sh/resource-policy: keep"
-Upgrade: false
+upgrade: false


### PR DESCRIPTION
We need to bump the helm chart version to include the new CRD changes that were applied with #414 

Also address an issue with making sure to fail when the `tembo-operator` Helm chart changes, but the version isn't updated.

Fix issues with `ct.yaml`