### PR TITLE
Ensure that the initial backups are completed before reconciliation finish

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/scripts/remove-minio.sh
+++ b/tembo-operator/scripts/remove-minio.sh
@@ -7,7 +7,7 @@ if [ -z "$1" ]; then
 fi
 
 # Start the port-forward in the background
-kubectl port-forward -n minio svc/minio 9000:9000 &
+kubectl port-forward -n minio svc/minio 9001:9000 &
 
 # Capture the process ID of the background process
 PORT_FORWARD_PID=$!
@@ -16,9 +16,9 @@ PORT_FORWARD_PID=$!
 sleep 1
 
 # Execute the AWS command
-AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 ls "s3://tembo-backup/" --endpoint-url http://localhost:9000
+AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 ls "s3://tembo-backup/" --endpoint-url http://localhost:9001
 echo "Removing backup $1 from Minio backup path s3://tembo-backup/"
-AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 rm "s3://tembo-backup/$1" --recursive --endpoint-url http://localhost:9000
+AWS_ACCESS_KEY_ID=tembo AWS_SECRET_ACCESS_KEY=tembo12345 aws s3 rm "s3://tembo-backup/$1" --recursive --endpoint-url http://localhost:9001
 
 # Kill the port-forward process
 kill $PORT_FORWARD_PID

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -4,6 +4,7 @@ use crate::{
         postgres_parameters::MergeError,
     },
     cloudnativepg::{
+        backups::Backup,
         clusters::{
             Cluster, ClusterAffinity, ClusterBackup, ClusterBackupBarmanObjectStore,
             ClusterBackupBarmanObjectStoreData, ClusterBackupBarmanObjectStoreDataCompression,
@@ -50,7 +51,7 @@ use crate::{
 use chrono::{DateTime, NaiveDateTime, Offset};
 use k8s_openapi::{api::core::v1::Pod, apimachinery::pkg::apis::meta::v1::ObjectMeta};
 use kube::{
-    api::{DeleteParams, Patch, PatchParams},
+    api::{DeleteParams, ListParams, Patch, PatchParams},
     runtime::{controller::Action, wait::Condition},
     Api, Resource, ResourceExt,
 };
@@ -729,9 +730,8 @@ async fn pods_to_fence(cdb: &CoreDB, ctx: Arc<Context>) -> Result<Vec<String>, A
     if cdb.spec.restore.is_some()
         && cdb
             .status
-            .clone()
-            .unwrap_or_default()
-            .first_recoverability_time
+            .as_ref()
+            .and_then(|s| s.first_recoverability_time.as_ref())
             .is_none()
     {
         // If restore is requested, fence all the pods based on the cdb.spec.replicas value
@@ -1709,6 +1709,49 @@ fn generate_s3_restore_credentials(
         ClusterExternalClustersBarmanObjectStoreS3Credentials {
             inherit_from_iam_role: Some(true),
             ..Default::default()
+        }
+    }
+}
+
+fn is_backup_completed(backup: &Backup) -> bool {
+    match &backup.status {
+        Some(status) => status.phase.as_deref() == Some("completed"),
+        None => false,
+    }
+}
+
+// Lookup the Backup status of the instance we are deploying.  If the backup isn't
+// complete, we will requeue until it is.
+pub async fn check_backups_status(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Action> {
+    let instance_name = cdb.name_any();
+    let namespace = cdb.namespace().ok_or_else(|| {
+        error!("Namespace is not set for CoreDB for instance {}", instance_name);
+        Action::requeue(Duration::from_secs(300))
+    })?;
+
+    let backups_api: Api<Backup> = Api::namespaced(ctx.client.clone(), &namespace);
+    let label_selector = format!("cnpg.io/cluster={},cnpg.io/immediateBackup=true", instance_name);
+    let lp = ListParams::default().labels(&label_selector);
+    let backup_result = backups_api.list(&lp).await;
+
+    match backup_result {
+        Ok(backup_list) => {
+            for backup_item in backup_list.items {
+                if let Some(backup_name) = &backup_item.metadata.name {
+                    if !is_backup_completed(&backup_item) {
+                        info!("Backup {} is not completed, requeuing", backup_name);
+                        return Err(Action::requeue(Duration::from_secs(30)));
+                    }
+                    info!("Backup {} completed", backup_name);
+                } else {
+                    warn!("Found backup with no name");
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            error!("Error listing backups: {}", e);
+            Err(Action::requeue(Duration::from_secs(300)))
         }
     }
 }

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -6,7 +6,10 @@ use crate::{
     app_service::manager::reconcile_app_services,
     cloudnativepg::{
         backups::Backup,
-        cnpg::{cnpg_cluster_from_cdb, reconcile_cnpg, reconcile_cnpg_scheduled_backup, reconcile_pooler},
+        cnpg::{
+            check_backups_status, cnpg_cluster_from_cdb, reconcile_cnpg, reconcile_cnpg_scheduled_backup,
+            reconcile_pooler,
+        },
     },
     config::Config,
     deployment_postgres_exporter::reconcile_prometheus_exporter_deployment,
@@ -308,6 +311,22 @@ impl CoreDB {
                 patch_cdb_status_merge(&coredbs, &name, patch_status).await?;
                 let (trunk_installs, extensions) =
                     reconcile_extensions(self, ctx.clone(), &coredbs, &name).await?;
+
+                // Make sure the initial backup has completed if enabled before finishing
+                // reconciliation of the CoreDB resource
+                if cfg.enable_backup
+                    && self
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.first_recoverability_time)
+                        .is_none()
+                {
+                    check_backups_status(self, ctx.clone()).await?;
+                    // if let Err(e) = check_backups_status(self, ctx.clone()).await {
+                    //     error!("Error checking backups status: {:?}", e);
+                    //     return Err(Action::requeue(Duration::from_secs(300)));
+                    // }
+                }
 
                 let recovery_time = self.get_recovery_time(ctx.clone()).await?;
 

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -313,8 +313,9 @@ impl CoreDB {
                     reconcile_extensions(self, ctx.clone(), &coredbs, &name).await?;
 
                 // Make sure the initial backup has completed if enabled before finishing
-                // reconciliation of the CoreDB resource
+                // reconciliation of the CoreDB resource that is being restored
                 if cfg.enable_backup
+                    && self.spec.restore.is_some()
                     && self
                         .status
                         .as_ref()
@@ -322,10 +323,6 @@ impl CoreDB {
                         .is_none()
                 {
                     check_backups_status(self, ctx.clone()).await?;
-                    // if let Err(e) = check_backups_status(self, ctx.clone()).await {
-                    //     error!("Error checking backups status: {:?}", e);
-                    //     return Err(Action::requeue(Duration::from_secs(300)));
-                    // }
                 }
 
                 let recovery_time = self.get_recovery_time(ctx.clone()).await?;


### PR DESCRIPTION
If you have a scenario where you are restoring a large database the backup may take a very long time.  We need to hold off on full reconciliation until the backup is complete.

This adds some functionality to check  for backups upon the first reconciliation loop to ensure that the initial backup is ran and completes successfully before we finish a reconcile.

Fixes: [TEM-2594](https://linear.app/tembo/issue/TEM-2594/large-restores-restart-in-a-loop)

Todo: 
* Writing/Updating tests.