### PR TITLE
Mount certs from secret in app services

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -3081,6 +3081,16 @@ mod test {
         let app_1_resources = app_1_container.resources.unwrap();
         assert_eq!(app_1_resources, expected);
 
+        // Assert /tembo/certs is included in volume mounts
+        let volume_mounts = app_1_container.volume_mounts.unwrap();
+        let mut found = false;
+        for mount in volume_mounts {
+            if mount.mount_path == "/tembo/certs" {
+                found = true;
+            }
+        }
+        assert!(found);
+
         let ingresses: Result<Vec<IngressRoute>, errors::OperatorError> =
             list_resources(client.clone(), cdb_name, &namespace, 1).await;
         let ingress = ingresses.unwrap();
@@ -3156,6 +3166,16 @@ mod test {
         .unwrap();
         let app_2_resources = app_2_container.resources.unwrap();
         assert_eq!(app_2_resources, expected);
+
+        // Assert /tembo/certs is included in volume mounts
+        let volume_mounts = app_2_container.volume_mounts.unwrap();
+        let mut found = false;
+        for mount in volume_mounts {
+            if mount.mount_path == "/tembo/certs" {
+                found = true;
+            }
+        }
+        assert!(found);
 
         // Delete the one without a service, but leave the postgrest appService
         let coredb_json = serde_json::json!({

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -3018,6 +3018,33 @@ mod test {
                                 "value": "/certs/tls.crt"
                             },
                         ],
+                        "storage": {
+                            "volumes": [
+                                {
+                                    "name": "ferretdb-data",
+                                    "ephemeral": {
+                                        "volumeClaimTemplate": {
+                                            "spec": {
+                                                "accessModes": [
+                                                    "ReadWriteOnce"
+                                                ],
+                                                "resources": {
+                                                    "requests": {
+                                                        "storage": "1Gi"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "volumeMounts": [
+                                {
+                                    "name": "ferretdb-data",
+                                    "mountPath": "/state"
+                                }
+                            ]
+                        },
                     }
                 ],
                 "postgresExporterEnabled": false
@@ -3046,6 +3073,38 @@ mod test {
         assert_eq!(app_0.metadata.name.unwrap(), format!("{cdb_name}-ferretdb"));
         assert_eq!(app_1.metadata.name.unwrap(), format!("{cdb_name}-postgrest"));
         assert_eq!(app_2.metadata.name.unwrap(), format!("{cdb_name}-test-app-1"));
+
+        let selector_map = app_0
+            .spec
+            .as_ref()
+            .and_then(|s| s.selector.match_labels.as_ref())
+            .expect("Deployment should have a selector");
+        let selector = selector_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join(",");
+        let lp = ListParams::default().labels(&selector);
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+        let pod_list = pods.list(&lp).await.unwrap();
+        assert_eq!(pod_list.items.len(), 1);
+        let app_0_pod = pod_list.items[0].clone();
+        let app_0_container = app_0_pod.spec.unwrap().containers[0].clone();
+
+        // Assert app_0 volume mounts include ferretdb-data and tembo-certs
+        let volume_mounts = app_0_container.volume_mounts.unwrap();
+        let mut found_ferretdb_data = false;
+        let mut found_tembo_certs = false;
+        for mount in volume_mounts {
+            if mount.mount_path == "/state" {
+                found_ferretdb_data = true;
+            }
+            if mount.mount_path == "/tembo/certs" {
+                found_tembo_certs = true;
+            }
+        }
+        assert!(found_ferretdb_data);
+        assert!(found_tembo_certs);
 
         // Assert resources in first appService
         // select the pod

--- a/tembo-operator/yaml/sample-document.yaml
+++ b/tembo-operator/yaml/sample-document.yaml
@@ -24,9 +24,9 @@ spec:
         - name: FERRETDB_STATE_DIR
           value: '-'
         - name: FERRETDB_LISTEN_TLS_CERT_FILE
-          value: /certs/tls.crt
+          value: /tembo/certs/tls.crt
         - name: FERRETDB_LISTEN_TLS_KEY_FILE
-          value: /certs/tls.key
+          value: /tembo/certs/tls.key
         - name: FERRETDB_LISTEN_TLS
           value: :27018
       storage:
@@ -40,12 +40,6 @@ spec:
                   resources:
                     requests:
                       storage: 1Gi
-          - name: ferretdb-certs
-            secret:
-              secretName: sample-document-server1
         volumeMounts:
             - name: ferretdb-data
               mountPath: /state
-            - name: ferretdb-certs
-              mountPath: /certs
-              readOnly: true


### PR DESCRIPTION
Some app services need to mount values from a secret `<coredb-name>-server1`. We don't have a good way to template the secret name into our Stacks definition, so adding this as a volume / volume mount for all app services. In the future this could be conditional.