### PR TITLE
update how we handle fencing restore instances

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.26.1"
+version = "0.27.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -6,10 +6,7 @@ use crate::{
     app_service::manager::reconcile_app_services,
     cloudnativepg::{
         backups::Backup,
-        cnpg::{
-            check_backups_status, cnpg_cluster_from_cdb, reconcile_cnpg, reconcile_cnpg_scheduled_backup,
-            reconcile_pooler,
-        },
+        cnpg::{cnpg_cluster_from_cdb, reconcile_cnpg, reconcile_cnpg_scheduled_backup, reconcile_pooler},
     },
     config::Config,
     deployment_postgres_exporter::reconcile_prometheus_exporter_deployment,
@@ -311,19 +308,6 @@ impl CoreDB {
                 patch_cdb_status_merge(&coredbs, &name, patch_status).await?;
                 let (trunk_installs, extensions) =
                     reconcile_extensions(self, ctx.clone(), &coredbs, &name).await?;
-
-                // Make sure the initial backup has completed if enabled before finishing
-                // reconciliation of the CoreDB resource that is being restored
-                if cfg.enable_backup
-                    && self.spec.restore.is_some()
-                    && self
-                        .status
-                        .as_ref()
-                        .and_then(|s| s.first_recoverability_time)
-                        .is_none()
-                {
-                    check_backups_status(self, ctx.clone()).await?;
-                }
 
                 let recovery_time = self.get_recovery_time(ctx.clone()).await?;
 


### PR DESCRIPTION
There is still an issue where a restore instance will get fenced even after it's fully reconciled.  This is a new attempt to fix the issue.

The issue complicated to explain without showing what happens in real time, but I will do my best

- Restore initiated and the operator starts the reconciliation process

- The operator fences the pod because it's a restore.  This is done right after we call `reconcile_cnpg`.  This logic currently looks for restore is present and `first_recoverability_time` is empty, which at this time is true and should be true.

- Once the restore is complete, the backup starts up but if it's a large DB this could take some time, as you know.
 
- Due to the backup time `first_recoverability_time` will still be empty on subsequent reconcile loops.  Though currently there is [this logic](https://github.com/tembo-io/tembo/blob/a377faa100b7b17cb8094680e0f551d9feb04b9f/tembo-operator/src/controller.rs#L317-L326) I put in place with #416 , it is removed in this PR.
 
- This appears to work (at least checking for the backup being complete), but for some reason it completes and the `let recovery_time = self.get_recovery_time(ctx.clone()).await?;` call still returns a `None` value for `first_recoverability_time`.  Maybe this happens too fast?  It's happening every time, regardless.
 
- Upon the next reconciliation the pod gets fenced again due to `first_recoverability_time` not being set.  Once reconciled again, then the issue is fixed.  This is why when restoring a large instance, the instance will restart again after the backup is completed.