### PR TITLE
uses instance_name from tembo.toml as local container name

### DIFF
--- a/tembo-cli/examples/single-instance/tembo.toml
+++ b/tembo-cli/examples/single-instance/tembo.toml
@@ -1,15 +1,15 @@
 # Tembo.toml configuration file version
-#version = "1.0.0"
+# version = "1.0.0"
 
 # Default settings for instances
 [defaults]
 environment = "dev"
-instance_name = "test-via-cli-9"
+instance_name = "test-via-cli-35"
 cpu = "1"
 memory = "2Gi"
 storage = "10Gi"
 replicas = 1
-stack_type = "OLTP"
+stack_type = "Standard"
 
 [defaults.postgres_configurations]
 shared_preload_libraries = 'pg_stat_statements'

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -41,19 +41,18 @@ impl Docker {
     }
 
     // Build & run docker image
-    pub fn build_run() -> Result {
+    pub fn build_run(instance_name: String) -> Result {
         let mut sp = Spinner::new(Spinners::Line, "Running Docker Build & Run".into());
-        let container_name = "tembo-pg";
 
-        if Self::container_list_filtered(container_name)
+        if Self::container_list_filtered(&instance_name)
             .unwrap()
-            .contains(container_name)
+            .contains(&instance_name)
         {
             sp.stop_with_message("- Existing container found".to_string());
         } else {
             let command = format!(
                 "docker build . -t postgres && docker run --name {} -p 5432:5432 -d postgres",
-                container_name
+                instance_name
             );
             run_command(&command)?;
             sp.stop_with_message("- Docker Build & Run completed".to_string());
@@ -80,9 +79,9 @@ impl Docker {
 
         if !Self::container_list_filtered(name)
             .unwrap()
-            .contains("tembo-pg")
+            .contains(name)
         {
-            sp.stop_with_message(format!("- Tembo instance {} doesn't exist", "tembo-pg"));
+            sp.stop_with_message(format!("- Tembo instance {} doesn't exist", name));
         } else {
             let mut command: String = String::from("docker stop ");
             command.push_str(name);

--- a/tembo-cli/src/cli/file_utils.rs
+++ b/tembo-cli/src/cli/file_utils.rs
@@ -47,7 +47,17 @@ impl FileUtils {
         Ok(())
     }
 
-    pub fn download_file(file_path: &str, download_location: &str) -> std::io::Result<()> {
+    pub fn download_file(
+        file_path: &str,
+        download_location: &str,
+        recreate: bool,
+    ) -> std::io::Result<()> {
+        let path = Path::new(&download_location);
+        if !recreate && path.exists() {
+            info!("Tembo {} file exists", download_location);
+            return Ok(());
+        }
+
         let mut dst = Vec::new();
         let mut easy = Easy::new();
         easy.url(file_path).unwrap();

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -73,13 +73,14 @@ fn execute_docker() -> Result<()> {
     FileUtils::create_file(
         POSTGRESCONF_NAME.to_string(),
         POSTGRESCONF_NAME.to_string(),
-        get_postgres_config(instance_settings),
+        get_postgres_config(instance_settings.clone()),
         true,
     )?;
 
-    Docker::build_run()?;
-
-    Docker::run_sqlx_migrate()?;
+    for (_key, value) in instance_settings.iter() {
+        Docker::build_run(value.instance_name.clone())?;
+        Docker::run_sqlx_migrate()?;
+    }
 
     // If all of the above was successful, we can print the url to user
     println!(">>> Tembo instance is now running on: postgres://postgres:postgres@localhost:5432");
@@ -326,7 +327,7 @@ pub fn get_rendered_dockerfile(
     let filepath =
         "https://raw.githubusercontent.com/tembo-io/tembo-cli/main/tembo/Dockerfile.template";
 
-    FileUtils::download_file(filepath, filename)?;
+    FileUtils::download_file(filepath, filename, true)?;
 
     let contents = match fs::read_to_string(filename) {
         Ok(c) => c,
@@ -359,7 +360,7 @@ pub fn get_rendered_migrations_file(
     let filepath =
         "https://raw.githubusercontent.com/tembo-io/tembo-cli/main/tembo/migrations.sql.template";
 
-    FileUtils::download_file(filepath, filename)?;
+    FileUtils::download_file(filepath, filename, true)?;
 
     let contents = match fs::read_to_string(filename) {
         Ok(c) => c,

--- a/tembo-cli/src/cmd/delete.rs
+++ b/tembo-cli/src/cmd/delete.rs
@@ -23,8 +23,12 @@ pub fn make_subcommand() -> Command {
 pub fn execute(_args: &ArgMatches) -> Result<()> {
     let env = get_current_context()?;
 
+    let instance_settings: HashMap<String, InstanceSettings> = get_instance_settings()?;
+
     if env.target == Target::Docker.to_string() {
-        Docker::stop_remove("tembo-pg")?;
+        for (_key, value) in instance_settings.iter() {
+            Docker::stop_remove(&value.instance_name.clone())?;
+        }
     } else if env.target == Target::TemboCloud.to_string() {
         return execute_tembo_cloud(env);
     }

--- a/tembo-cli/src/cmd/init.rs
+++ b/tembo-cli/src/cmd/init.rs
@@ -47,17 +47,11 @@ pub fn execute(_args: &ArgMatches) -> Result<()> {
         }
     }
 
-    match FileUtils::create_file(
-        "config".to_string(),
-        "tembo.toml".to_string(),
-        "".to_string(),
-        false,
-    ) {
-        Ok(t) => t,
-        Err(e) => {
-            return Err(e);
-        }
-    }
+    let filename = "tembo.toml";
+    let filepath =
+        "https://raw.githubusercontent.com/tembo-io/tembo/main/tembo-cli/examples/single-instance/tembo.toml";
+
+    FileUtils::download_file(filepath, filename, false)?;
 
     match FileUtils::create_dir("migrations directory".to_string(), "migrations".to_string()) {
         Ok(t) => t,

--- a/tembo-cli/src/main.rs
+++ b/tembo-cli/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(file_create_new)]
-
 #[macro_use]
 extern crate clap;
 extern crate log;


### PR DESCRIPTION
* Uses `instance_name` from tembo.toml as local container name
* Creating tembo.toml file from `examples/single-instance/tembo.toml` when running `tembo init`