### PR TITLE
change ingress path on vector db app

### DIFF
--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -7,14 +7,14 @@ appServices:
     name: embeddings
     routing:
       - port: 3000
-        ingressPath: /transform
+        ingressPath: /vectordb
         middlewares:
           - map-embeddings
     middlewares:
       - !replacePathRegex
           name: map-embeddings
           config:
-            regex: \/transform\/?
+            regex: ^\/vectordb\/?
             replacement: /
     resources:
       requests:

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -7,14 +7,14 @@ appServices:
     name: embeddings
     routing:
       - port: 3000
-        ingressPath: /embeddings
+        ingressPath: /transform
         middlewares:
           - map-embeddings
     middlewares:
       - !replacePathRegex
           name: map-embeddings
           config:
-            regex: \/embeddings\/?
+            regex: \/transform\/?
             replacement: /
     resources:
       requests:


### PR DESCRIPTION
ergonomics are weird. the public facing endpoint ends up being `{domain}/embeddings/v1/embeddings`. This will make it `/vectordb/v1/embeddings` instead.