### PR TITLE
Add pg_stat_statements.

### DIFF
--- a/tembo-operator/src/stacks/templates/mongo_adapter.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_adapter.yaml
@@ -56,6 +56,15 @@ compute_templates:
     memory: 32Gi
   - cpu: 16
     memory: 32Gi
+trunk_installs:
+  - name: pg_stat_statements
+    version: 1.10.0
+extensions:
+  - name: pg_stat_statements
+    locations:
+      - database: postgres
+        enabled: true
+        version: 1.10.0
 postgres_config_engine: standard
 postgres_config:
   - name: autovacuum_vacuum_cost_limit


### PR DESCRIPTION
Add pg_stat_statements extension as a default to mongo adapter stack.