### PR TITLE
Add config to set target database for metric query

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.29.0"
+version = "0.29.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/app_service/ingress.rs
+++ b/tembo-operator/src/app_service/ingress.rs
@@ -262,7 +262,7 @@ pub fn generate_ingress_tcp_routes(
             let mut routes: Vec<IngressRouteTCPRoutes> = Vec::new();
             for route in routings.iter() {
                 match route.ingress_path.clone() {
-                    Some(path) => {
+                    Some(_path) => {
                         if !route.ingress_type.clone()?.eq(&IngressType::tcp) {
                             // Do not create IngressRouteTCPRoutes for non-TCP ingress type
                             debug!("Skipping IngressRouteTCPRoutes for non-TCP ingress type");

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -65,6 +65,10 @@ pub fn default_postgres_exporter_image() -> String {
     "quay.io/prometheuscommunity/postgres-exporter:v0.12.0".to_owned()
 }
 
+pub fn default_postgres_exporter_target_databases() -> Vec<String> {
+    vec!["postgres".to_owned()]
+}
+
 pub fn default_extensions() -> Vec<Extension> {
     vec![]
 }

--- a/tembo-operator/src/lib.rs
+++ b/tembo-operator/src/lib.rs
@@ -47,6 +47,9 @@ pub enum Error {
     #[error("SerializationError: {0}")]
     SerializationError(#[source] serde_json::Error),
 
+    #[error("SerializationError: {0}")]
+    YamlSerializationError(#[source] serde_yaml::Error),
+
     #[error("Kube Error: {0}")]
     KubeError(#[from] kube::Error),
 
@@ -69,5 +72,11 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 impl Error {
     pub fn metric_label(&self) -> String {
         format!("{self:?}").to_lowercase()
+    }
+}
+
+impl From<serde_yaml::Error> for Error {
+    fn from(err: serde_yaml::Error) -> Self {
+        Error::YamlSerializationError(err)
     }
 }

--- a/tembo-operator/src/postgres_exporter.rs
+++ b/tembo-operator/src/postgres_exporter.rs
@@ -235,7 +235,8 @@ mod tests {
                         "description": "Time at which postmaster started"
                       }
                     }
-                  ]
+                  ],
+                  "target_databases": ["postgres"]
                 },
                 "extensions": {
                   "query": "select count(*) as num_ext from pg_available_extensions",
@@ -247,7 +248,8 @@ mod tests {
                         "description": "Num extensions"
                       }
                     }
-                  ]
+                  ],
+                  "target_databases": ["postgres"]
                 }
               }
         );
@@ -298,6 +300,8 @@ mod tests {
   - num_ext:
       usage: GAUGE
       description: Num extensions
+  target_databases:
+  - postgres
 pg_postmaster:
   query: SELECT pg_postmaster_start_time as start_time_seconds from pg_postmaster_start_time()
   master: true
@@ -305,6 +309,8 @@ pg_postmaster:
   - start_time_seconds:
       usage: GAUGE
       description: Time at which postmaster started
+  target_databases:
+  - postgres
 "#;
         // formmatted correctly as yaml (for configmap)
         assert_eq!(yaml, data);

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -95,6 +95,8 @@ postgres_metrics:
         - total_messages:
             usage: GAUGE
             description: Total number of messages that have passed into the queue.
+      target_databases:
+        - "postgres"
 postgres_config_engine: mq
 postgres_config:
   - name: shared_preload_libraries

--- a/tembo-operator/yaml/sample-message-queue.yaml
+++ b/tembo-operator/yaml/sample-message-queue.yaml
@@ -55,7 +55,7 @@ spec:
     image: quay.io/prometheuscommunity/postgres-exporter:v0.12.0
     queries:
       pgmq:
-        query: select queue_name, queue_length, oldest_msg_age_sec, newest_msg_age_sec, total_messages from public.pgmq_metrics_all()
+        query: select queue_name, queue_length, oldest_msg_age_sec, newest_msg_age_sec, total_messages from pgmq.metrics_all()
         master: true
         metrics:
           - queue_name:
@@ -73,6 +73,8 @@ spec:
           - total_messages:
               description: Total number of messages that have passed into the queue.
               usage: GAUGE
+        target_databases:
+          - "postgres"
   runtime_config:
     - name: shared_buffers
       value: "1024MB"


### PR DESCRIPTION
To fix issues where the default query for metrics is using the correct database.

This config is taken directly from the [CNPG docs](https://cloudnative-pg.io/documentation/1.20/monitoring/#example-of-a-user-defined-metric-running-on-multiple-databases)

Fixes: [TEM-2666](https://linear.app/tembo/issue/TEM-2666/add-target-database-for-metrics-query)