### PR TITLE
runs validate before running apply to find any validation errors right away.

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -65,7 +65,7 @@ impl Docker {
     }
 
     fn get_available_port() -> Result<i32> {
-        let ls_command = "docker ps -a --format '{{.Ports}}'";
+        let ls_command = "docker ps --format '{{.Ports}}'";
 
         let output = ShellCommand::new("sh")
             .arg("-c")

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -41,7 +41,7 @@ impl Docker {
     }
 
     // Build & run docker image
-    pub fn build_run(instance_name: String) -> Result<(), anyhow::Error> {
+    pub fn build_run(instance_name: String) -> Result<i32, anyhow::Error> {
         let mut sp = Spinner::new(Spinners::Line, "Running Docker Build & Run".into());
         let container_list = Self::container_list_filtered(&instance_name).unwrap();
 
@@ -63,7 +63,7 @@ impl Docker {
         }
     }
 
-    fn get_available_port() -> Result<i32> {
+    fn get_available_port() -> Result<i32, anyhow::Error> {
         let ls_command = "docker ps --format '{{.Ports}}'";
 
         let output = ShellCommand::new("sh")
@@ -76,7 +76,7 @@ impl Docker {
         Docker::get_container_port(stdout)
     }
 
-    fn get_container_port(container_list: String) -> Result<i32> {
+    fn get_container_port(container_list: String) -> Result<i32, anyhow::Error> {
         if container_list.contains("5432") {
             if container_list.contains("5433") {
                 if container_list.contains("5434") {

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -10,6 +10,7 @@ use anyhow::Error;
 use clap::{ArgMatches, Command};
 use controller::stacks::get_stack;
 use controller::stacks::types::StackType as ControllerStackType;
+use log::info;
 use spinners::{Spinner, Spinners};
 use std::{
     collections::HashMap,
@@ -43,6 +44,10 @@ pub fn make_subcommand() -> Command {
 }
 
 pub fn execute(_args: &ArgMatches) -> Result<()> {
+    info!("Running validation!");
+    super::validate::execute(&ArgMatches::default())?;
+    info!("Validation completed!");
+
     let env = get_current_context()?;
 
     if env.target == Target::Docker.to_string() {


### PR DESCRIPTION
Merry Christmas! 

* Calls `tembo validate` at the start of `tembo apply` to find any validation errors right away
* If `5432` port is taken it uses `5433` or `5434` to run a docker container for local context