### PR TITLE
Tembo CLI apply improvements

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.12.1"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -1,9 +1,11 @@
-use anyhow::bail;
+use std::io::{BufRead, BufReader};
+use anyhow::{bail, Context};
 use anyhow::Error;
 use simplelog::*;
 use spinners::{Spinner, Spinners};
-use std::process::Command as ShellCommand;
+use std::process::{Command as ShellCommand, Stdio};
 use std::process::Output;
+use std::thread;
 
 pub struct Docker {}
 
@@ -42,25 +44,43 @@ impl Docker {
 
     // Build & run docker image
     pub fn build_run(instance_name: String) -> Result<i32, anyhow::Error> {
-        let mut sp = Spinner::new(Spinners::Line, "Running Docker Build & Run".into());
-        let container_list = Self::container_list_filtered(&instance_name).unwrap();
+        let verbose = false;
+        let mut sp = if !verbose {
+            Some(Spinner::new(Spinners::Line, "Running Docker Build & Run".into()))
+        } else {
+            None
+        };
+
+        let container_list = Self::container_list_filtered(&instance_name)?;
 
         if container_list.contains(&instance_name) {
             let container_port = Docker::get_container_port(container_list)?;
 
-            sp.stop_with_message("- Existing container found".to_string());
-            Ok(container_port)
-        } else {
-            let port = Docker::get_available_port()?;
+            if verbose {
+                println!("- Existing container found, removing");
+            } else {
+                sp.as_mut().unwrap().stop_with_message("- Existing container found, removing".to_string());
+                sp = Some(Spinner::new(Spinners::Line, "- Building and running container".into()))
+            }
 
-            let command = format!(
-                "docker build . -t postgres && docker run --name {} -p {}:{} -d postgres",
-                instance_name, port, port
-            );
-            run_command(&command)?;
-            sp.stop_with_message("- Docker Build & Run completed".to_string());
-            Ok(port)
+            Docker::stop_remove(&instance_name)?;
         }
+
+        let port = Docker::get_available_port()?;
+
+        let command = format!(
+            "docker build . -t postgres-{} && docker run --rm --name {} -p {}:{} -d postgres-{}",
+            instance_name, instance_name, port, port, instance_name
+        );
+        run_command(&command, verbose)?;
+
+        if verbose {
+            println!("- Docker Build & Run completed");
+        } else {
+            sp.as_mut().unwrap().stop_with_message("- Docker Build & Run completed".to_string());
+        }
+
+        Ok(port)
     }
 
     fn get_available_port() -> Result<i32, anyhow::Error> {
@@ -101,16 +121,19 @@ impl Docker {
         if !Self::container_list_filtered(name).unwrap().contains(name) {
             sp.stop_with_message(format!("- Tembo instance {} doesn't exist", name));
         } else {
-            let mut command: String = String::from("docker stop ");
-            command.push_str(name);
-            command.push_str(" && docker rm ");
+            let mut command: String = String::from("docker rm --force ");
             command.push_str(name);
 
-            let output = ShellCommand::new("sh")
+            let output = match ShellCommand::new("sh")
                 .arg("-c")
                 .arg(&command)
-                .output()
-                .expect("failed to execute process");
+                .output() {
+                Ok(output) => {output}
+                Err(_) => {
+                    sp.stop_with_message(format!("- Tembo instance {} failed to stop & remove", &name));
+                    bail!("There was an issue stopping the instance")
+                }
+            };
 
             sp.stop_with_message(format!("- Tembo instance {} stopped & removed", &name));
 
@@ -122,21 +145,6 @@ impl Docker {
         }
 
         Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn container_list() -> Result<String, anyhow::Error> {
-        let mut ls_command = String::from("cd tembo "); // TODO: does this work for installed crates?
-        ls_command.push_str("&& docker ls --all");
-
-        let output = ShellCommand::new("sh")
-            .arg("-c")
-            .arg(&ls_command)
-            .output()
-            .expect("failed to execute process");
-        let stdout = String::from_utf8(output.stdout);
-
-        Ok(stdout.unwrap())
     }
 
     pub fn container_list_filtered(name: &str) -> Result<String, anyhow::Error> {
@@ -153,18 +161,49 @@ impl Docker {
     }
 }
 
-pub fn run_command(command: &str) -> Result<(), anyhow::Error> {
-    let output = ShellCommand::new("sh")
+pub fn run_command(command: &str, verbose: bool) -> Result<(), anyhow::Error> {
+    let mut child = ShellCommand::new("sh")
         .arg("-c")
         .arg(command)
-        .output()
-        .expect("failed to execute process");
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("Failed to spawn command '{}'", command))?;
 
-    // Using output status to determine whether there is an error or not
-    // because stderr returns a value even when there is no error
-    if !output.status.success() {
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        bail!("There was an issue running command: {}", stderr)
+    if verbose {
+        let stdout = BufReader::new(
+            child.stdout.take().expect("Failed to open stdout")
+        );
+        let stderr = BufReader::new(
+            child.stderr.take().expect("Failed to open stderr")
+        );
+
+        let stdout_handle = thread::spawn(move || {
+            for line in stdout.lines() {
+                match line {
+                    Ok(line) => println!("{}", line),
+                    Err(e) => eprintln!("Error reading line from stdout: {}", e),
+                }
+            }
+        });
+
+        let stderr_handle = thread::spawn(move || {
+            for line in stderr.lines() {
+                match line {
+                    Ok(line) => eprintln!("{}", line),
+                    Err(e) => eprintln!("Error reading line from stderr: {}", e),
+                }
+            }
+        });
+
+        stdout_handle.join().expect("Stdout thread panicked");
+        stderr_handle.join().expect("Stderr thread panicked");
+    }
+
+    let status = child.wait().expect("Failed to wait on child");
+
+    if !status.success() {
+        bail!("Command executed with failures");
     }
 
     Ok(())

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -43,8 +43,7 @@ impl Docker {
     }
 
     // Build & run docker image
-    pub fn build_run(instance_name: String) -> Result<i32, anyhow::Error> {
-        let verbose = false;
+    pub fn build_run(instance_name: String, verbose: bool) -> Result<i32, anyhow::Error> {
         let mut sp = if !verbose {
             Some(Spinner::new(Spinners::Line, "Running Docker Build & Run".into()))
         } else {
@@ -54,8 +53,6 @@ impl Docker {
         let container_list = Self::container_list_filtered(&instance_name)?;
 
         if container_list.contains(&instance_name) {
-            let container_port = Docker::get_container_port(container_list)?;
-
             if verbose {
                 println!("- Existing container found, removing");
             } else {

--- a/tembo-cli/src/cli/docker.rs
+++ b/tembo-cli/src/cli/docker.rs
@@ -1,10 +1,10 @@
-use std::io::{BufRead, BufReader};
-use anyhow::{bail, Context};
 use anyhow::Error;
+use anyhow::{bail, Context};
 use simplelog::*;
 use spinners::{Spinner, Spinners};
-use std::process::{Command as ShellCommand, Stdio};
+use std::io::{BufRead, BufReader};
 use std::process::Output;
+use std::process::{Command as ShellCommand, Stdio};
 use std::thread;
 
 pub struct Docker {}
@@ -45,7 +45,10 @@ impl Docker {
     // Build & run docker image
     pub fn build_run(instance_name: String, verbose: bool) -> Result<i32, anyhow::Error> {
         let mut sp = if !verbose {
-            Some(Spinner::new(Spinners::Line, "Running Docker Build & Run".into()))
+            Some(Spinner::new(
+                Spinners::Line,
+                "Running Docker Build & Run".into(),
+            ))
         } else {
             None
         };
@@ -56,8 +59,13 @@ impl Docker {
             if verbose {
                 println!("- Existing container found, removing");
             } else {
-                sp.as_mut().unwrap().stop_with_message("- Existing container found, removing".to_string());
-                sp = Some(Spinner::new(Spinners::Line, "- Building and running container".into()))
+                sp.as_mut()
+                    .unwrap()
+                    .stop_with_message("- Existing container found, removing".to_string());
+                sp = Some(Spinner::new(
+                    Spinners::Line,
+                    "- Building and running container".into(),
+                ))
             }
 
             Docker::stop_remove(&instance_name)?;
@@ -74,7 +82,9 @@ impl Docker {
         if verbose {
             println!("- Docker Build & Run completed");
         } else {
-            sp.as_mut().unwrap().stop_with_message("- Docker Build & Run completed".to_string());
+            sp.as_mut()
+                .unwrap()
+                .stop_with_message("- Docker Build & Run completed".to_string());
         }
 
         Ok(port)
@@ -121,13 +131,13 @@ impl Docker {
             let mut command: String = String::from("docker rm --force ");
             command.push_str(name);
 
-            let output = match ShellCommand::new("sh")
-                .arg("-c")
-                .arg(&command)
-                .output() {
-                Ok(output) => {output}
+            let output = match ShellCommand::new("sh").arg("-c").arg(&command).output() {
+                Ok(output) => output,
                 Err(_) => {
-                    sp.stop_with_message(format!("- Tembo instance {} failed to stop & remove", &name));
+                    sp.stop_with_message(format!(
+                        "- Tembo instance {} failed to stop & remove",
+                        &name
+                    ));
                     bail!("There was an issue stopping the instance")
                 }
             };
@@ -168,12 +178,8 @@ pub fn run_command(command: &str, verbose: bool) -> Result<(), anyhow::Error> {
         .with_context(|| format!("Failed to spawn command '{}'", command))?;
 
     if verbose {
-        let stdout = BufReader::new(
-            child.stdout.take().expect("Failed to open stdout")
-        );
-        let stderr = BufReader::new(
-            child.stderr.take().expect("Failed to open stderr")
-        );
+        let stdout = BufReader::new(child.stdout.take().expect("Failed to open stdout"));
+        let stderr = BufReader::new(child.stderr.take().expect("Failed to open stderr"));
 
         let stdout_handle = thread::spawn(move || {
             for line in stdout.lines() {

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -39,7 +39,7 @@ const POSTGRESCONF_NAME: &str = "postgres.conf";
 #[derive(Args)]
 pub struct ApplyCommand {}
 
-pub fn execute() -> Result<(), anyhow::Error> {
+pub fn execute(verbose: bool) -> Result<(), anyhow::Error> {
     info!("Running validation!");
     super::validate::execute()?;
     info!("Validation completed!");
@@ -47,7 +47,7 @@ pub fn execute() -> Result<(), anyhow::Error> {
     let env = get_current_context()?;
 
     if env.target == Target::Docker.to_string() {
-        return execute_docker();
+        return execute_docker(verbose);
     } else if env.target == Target::TemboCloud.to_string() {
         return execute_tembo_cloud(env.clone());
     }
@@ -55,7 +55,7 @@ pub fn execute() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn execute_docker() -> Result<(), anyhow::Error> {
+fn execute_docker(verbose: bool) -> Result<(), anyhow::Error> {
     Docker::installed_and_running()?;
 
     let instance_settings: HashMap<String, InstanceSettings> = get_instance_settings()?;
@@ -85,7 +85,7 @@ fn execute_docker() -> Result<(), anyhow::Error> {
     )?;
 
     for (_key, value) in instance_settings.iter() {
-        let port = Docker::build_run(value.instance_name.clone())?;
+        let port = Docker::build_run(value.instance_name.clone(), verbose)?;
 
         // Allows DB instance to be ready before running migrations
         sleep(Duration::from_secs(3));

--- a/tembo-cli/src/main.rs
+++ b/tembo-cli/src/main.rs
@@ -1,7 +1,7 @@
 use crate::cmd::delete::DeleteCommand;
 use crate::cmd::validate::ValidateCommand;
 use crate::cmd::{apply, context, delete, init, validate};
-use clap::{crate_authors, crate_version, Parser, Subcommand};
+use clap::{crate_authors, crate_version, Parser, Subcommand, Args};
 use cmd::apply::ApplyCommand;
 use cmd::context::{ContextCommand, ContextSubCommand};
 use cmd::init::InitCommand;
@@ -12,6 +12,9 @@ mod cmd;
 #[derive(Parser)]
 #[clap(author = crate_authors!("\n"), version = crate_version!(), about = "Tembo CLI", long_about = None)]
 struct App {
+    #[clap(flatten)]
+    global_opts: GlobalOpts,
+
     #[clap(subcommand)]
     command: SubCommands,
 }
@@ -24,6 +27,13 @@ enum SubCommands {
     Apply(ApplyCommand),
     Validate(ValidateCommand),
     Delete(DeleteCommand),
+}
+
+#[derive(Args)]
+struct GlobalOpts {
+    /// Show more information in command output
+    #[clap(short, long)]
+    verbose: bool,
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -42,7 +52,7 @@ fn main() -> Result<(), anyhow::Error> {
             init::execute()?;
         }
         SubCommands::Apply(_apply_cmd) => {
-            apply::execute()?;
+            apply::execute(app.global_opts.verbose)?;
         }
         SubCommands::Validate(_validate_cmd) => {
             validate::execute()?;

--- a/tembo-cli/src/main.rs
+++ b/tembo-cli/src/main.rs
@@ -1,7 +1,7 @@
 use crate::cmd::delete::DeleteCommand;
 use crate::cmd::validate::ValidateCommand;
 use crate::cmd::{apply, context, delete, init, validate};
-use clap::{crate_authors, crate_version, Parser, Subcommand, Args};
+use clap::{crate_authors, crate_version, Args, Parser, Subcommand};
 use cmd::apply::ApplyCommand;
 use cmd::context::{ContextCommand, ContextSubCommand};
 use cmd::init::InitCommand;


### PR DESCRIPTION
- tembo apply delete + recreate if already exists
- tembo apply to local, always remove container when stopped
- tembo apply handle the case of container exists but stopped
- tembo apply can work with `tembo --verbose apply` to stream output from build + run to shell
- Include templates with build instead of download from github