### PR TITLE
Assume trunk project if possible in Tembo.toml

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-cli/src/cli/tembo_config.rs
+++ b/tembo-cli/src/cli/tembo_config.rs
@@ -53,10 +53,6 @@ where
     .map_or(Ok(None), |m| Ok(Some(m)))
 }
 
-fn default_extensions() -> Option<HashMap<String, Extension>> {
-    Some(HashMap::new())
-}
-
 fn default_cpu() -> String {
     "0.25".to_string()
 }
@@ -75,6 +71,10 @@ fn default_replicas() -> i32 {
 
 fn default_stack_type() -> String {
     "Standard".to_string()
+}
+
+fn default_extensions() -> Option<HashMap<String, Extension>> {
+    Some(HashMap::new())
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/tembo-cli/tests/integration_tests.rs
+++ b/tembo-cli/tests/integration_tests.rs
@@ -97,10 +97,9 @@ async fn data_warehouse() -> Result<(), Box<dyn Error>> {
 
     // check extensions includes postgres_fdw in the output
     // connecting to postgres and running the command
-    let result = get_output_from_sql(
-        "SELECT * FROM pg_extension WHERE extname = 'postgres_fdw'".to_string(),
-    );
-    assert!(result.await?.contains("postgres_fdw"));
+    let result =
+        get_output_from_sql("SELECT * FROM pg_extension WHERE extname = 'clerk_fdw'".to_string());
+    assert!(result.await?.contains("clerk_fdw"));
 
     // tembo delete
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;

--- a/tembo-cli/tests/tomls/data-warehouse/tembo.toml
+++ b/tembo-cli/tests/tomls/data-warehouse/tembo.toml
@@ -5,3 +5,7 @@ cpu = "2"
 memory = "8Gi"
 storage = "50Gi"
 stack_type = "DataWarehouse"
+
+[data-warehouse.extensions.clerk_fdw]
+enabled = true
+version = "0.2.4"


### PR DESCRIPTION
Allows for
```
[data-warehouse]
environment = "test"
instance_name = "data-warehouse"
cpu = "2"
memory = "8Gi"
storage = "50Gi"
stack_type = "DataWarehouse"

[data-warehouse.extensions.clerk_fdw]
enabled = true
version = "0.2.4"
```

Instead of needing
```
[data-warehouse]
environment = "test"
instance_name = "data-warehouse"
cpu = "2"
memory = "8Gi"
storage = "50Gi"
stack_type = "DataWarehouse"

[data-warehouse.extensions.clerk_fdw]
enabled = true
version = "0.2.4"
trunk_project = "clerk_fdw" #           <-------- this
```