### PR TITLE
Add trunk metadata helper functions

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.29.2"
+version = "0.30.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.29.4"
+version = "0.30.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -21,13 +21,12 @@ pub struct ExtensionRequiresLoad {
     pub library_name: String,
 }
 
-// TODO(ianstanton) Determine all optional fields
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize, ToSchema, JsonSchema)]
 pub struct TrunkProjectMetadata {
     pub name: String,
-    pub description: String,
-    pub documentation_link: String,
-    pub repository_link: String,
+    pub description: Option<String>,
+    pub documentation_link: Option<String>,
+    pub repository_link: Option<String>,
     pub version: String,
     pub postgres_versions: Vec<i32>,
     pub extensions: Vec<TrunkExtensionMetadata>,
@@ -40,7 +39,7 @@ pub struct TrunkExtensionMetadata {
     pub version: String,
     pub trunk_project_name: String,
     pub dependencies_extension_names: Option<Vec<String>>,
-    pub loadable_libraries: Vec<TrunkLoadableLibrariesMetadata>,
+    pub loadable_libraries: Option<Vec<TrunkLoadableLibrariesMetadata>>,
     pub configurations: Option<Vec<String>>,
     pub control_file: TrunkControlFileMetadata,
 }

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -165,10 +165,16 @@ async fn get_trunk_project_metadata(trunk_project: String) -> Result<Value, Trun
 }
 
 // Get trunk project metadata for a specific version
-async fn get_trunk_project_metadata_for_version(trunk_project: String, version: String) -> Result<Value, TrunkError> {
+async fn get_trunk_project_metadata_for_version(
+    trunk_project: String,
+    version: String,
+) -> Result<Value, TrunkError> {
     let domain = env::var("TRUNK_REGISTRY_DOMAIN")
         .unwrap_or_else(|_| DEFAULT_TRUNK_REGISTRY_DOMAIN.to_string());
-    let url = format!("https://{}/api/v1/trunk-projects/{}/version/{}", domain, trunk_project, version);
+    let url = format!(
+        "https://{}/api/v1/trunk-projects/{}/version/{}",
+        domain, trunk_project, version
+    );
 
     let response = reqwest::get(&url).await?;
 

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -234,7 +234,9 @@ pub async fn get_trunk_project_names() -> Result<Vec<String>, TrunkError> {
 }
 
 // Get all metadata entries for a given trunk project
-async fn get_trunk_project_metadata(trunk_project: String) -> Result<Value, TrunkError> {
+async fn get_trunk_project_metadata(
+    trunk_project: String,
+) -> Result<Vec<TrunkProjectMetadata>, TrunkError> {
     let domain = env::var("TRUNK_REGISTRY_DOMAIN")
         .unwrap_or_else(|_| DEFAULT_TRUNK_REGISTRY_DOMAIN.to_string());
     let url = format!("https://{}/api/v1/trunk-projects/{}", domain, trunk_project);
@@ -243,7 +245,7 @@ async fn get_trunk_project_metadata(trunk_project: String) -> Result<Value, Trun
 
     if response.status().is_success() {
         let response_body = response.text().await?;
-        let project_metadata: Value = serde_json::from_str(&response_body)?;
+        let project_metadata: Vec<TrunkProjectMetadata> = serde_json::from_str(&response_body)?;
         Ok(project_metadata)
     } else {
         error!(
@@ -510,7 +512,6 @@ mod tests {
         let extension_name = "auto_explain".to_string();
         let result = get_loadable_library_name(trunk_project, version, extension_name).await;
         assert!(result.is_ok());
-        println!("{:?}", result.clone().unwrap().unwrap());
         assert_eq!(result.unwrap(), Some("auto_explain".to_string()));
     }
 }

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -4,7 +4,6 @@ use lazy_static::lazy_static;
 use schemars::JsonSchema;
 use serde::de::Error;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::{collections::BTreeMap, env, time::Duration};
 
 use crate::configmap::apply_configmap;


### PR DESCRIPTION
This PR lays down some ground work related to https://linear.app/tembo/issue/TEM-2773/tembo-operator-handle-extensions-enabled-with-load. Opening this up in a series of PRs to avoid one massive PR.

Add helper functions for working with Trunk metadata:
- `get_trunk_projects`
- `get_trunk_project_names`
- `get_trunk_project_metadata`
- `get_trunk_project_metadata_for_version`
- `extension_name_matches_trunk_project`
- `get_trunk_project_for_extension`
- `is_control_file_absent`
- `get_loadable_library_name`

Also add `TrunkProjectMetadata` type definition. In the future, we can publish this as a crate lib and share across projects such as Trunk CLI and Registry