### PR TITLE
Handle the case of conflicting edit with kubectl

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.29.2"
+version = "0.29.4"
 dependencies = [
  "actix-web",
  "anyhow",


### PR DESCRIPTION
Noticed an issue for an instance where kubectl edit was used on the Cluster resource - this will allow controller to take back ownership.