### PR TITLE
Bump stack images

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.30.0"
+version = "0.30.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -1,6 +1,6 @@
 name: API
 description: Tembo Stack with REST and graphQL interfaces.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - image: postgrest/postgrest:v12.0.0

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -1,6 +1,6 @@
 name: DataWarehouse
 description: A Postgres instance equipped with configuration and extensions for building a data warehouse on Postgres.
-image: "quay.io/tembo/dw-cnpg:15.3.0-1-0baf38f"
+image: "quay.io/tembo/dw-cnpg:15.3.0-1-46c8b6f"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -1,6 +1,6 @@
 name: Geospatial
 description: Postgres for geospatial workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -1,6 +1,6 @@
 name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
-image: "quay.io/tembo/ml-cnpg:15.3.0-1-93dae54"
+image: "quay.io/tembo/ml-cnpg:15.3.0-1-46c8b6f"
 stack_version: 0.3.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -1,6 +1,6 @@
 name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.3.0
 appServices:
   - name: mq-api

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -1,6 +1,6 @@
 name: MongoAlternative
 description: Document-facing workloads on Postgres.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - name: fdb-api

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -1,6 +1,6 @@
 name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -1,6 +1,6 @@
 name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -1,6 +1,6 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -1,6 +1,6 @@
 name: VectorDB
 description: A Tembo Postgres Stack configured to support vector data types, storage, and operations.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:291da06


### PR DESCRIPTION
- Bump `standard-cnpg` to `795fc99`
- Bump `ml-cnpg` to `46c8b6f`
- Bump `dw-cnpg` to `46c8b6f`

Related to:
- https://github.com/tembo-io/tembo-images/pull/45
- https://github.com/tembo-io/tembo-images/pull/46