### PR TITLE
Handle extensions enabled with `LOAD`

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.30.4"
+version = "0.31.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.30.4"
+version = "0.31.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -53,7 +53,7 @@ fn merge_and_deduplicate_pods(
 
 // Collect any fenced pods and add them to the list of pods to install extensions into
 #[instrument(skip(ctx, cdb) fields(trace_id))]
-async fn all_fenced_and_non_fenced_pods(
+pub async fn all_fenced_and_non_fenced_pods(
     cdb: &CoreDB,
     ctx: Arc<Context>,
 ) -> Result<Vec<Pod>, Action> {
@@ -404,6 +404,83 @@ async fn execute_extension_install_command(
         }
     }
 }
+
+// Check if <extension_name>.so file exists for a given extension in /var/lib/postgresql/data/tembo/15/lib
+#[instrument(skip(cdb, ctx, pod_name) fields(trace_id))]
+pub async fn check_for_so_files(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+    pod_name: &str,
+    extension_name: String,
+) -> Result<bool, Action> {
+    let coredb_name = cdb.metadata.name.as_deref().unwrap_or_default();
+
+    info!(
+        "Checking for .so files in /var/lib/postgresql/data/tembo/15/lib for pod {} for {}",
+        pod_name, coredb_name
+    );
+
+    let client = ctx.client.clone();
+
+    // Check if the pod is up yet
+    if let Err(e) = cdb.log_pod_status(client.clone(), pod_name).await {
+        warn!(
+            "Could not fetch or log pod status for instance {}: {:?}",
+            coredb_name, e
+        );
+        return Err(Action::requeue(Duration::from_secs(10)));
+    }
+
+    let cmd = vec![
+        "ls".to_owned(),
+        "/var/lib/postgresql/data/tembo/15/lib".to_owned(),
+    ];
+
+    let result = cdb.exec(pod_name.to_string(), client.clone(), &cmd).await;
+
+    match result {
+        Ok(result) => {
+            let output = format!(
+                "{}\n{}",
+                result
+                    .stdout
+                    .unwrap_or_else(|| "Nothing in stdout".to_string()),
+                result
+                    .stderr
+                    .unwrap_or_else(|| "Nothing in stderr".to_string())
+            );
+
+            if result.success {
+                // Check if .so files exist in output
+                if output.contains(format!("{}.so", extension_name).as_str()) {
+                    info!(
+                        "Found {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}",
+                        extension_name, pod_name, coredb_name
+                    );
+                    return Ok(true);
+                }
+                info!(
+                    "No .so files found in /usr/local/lib/postgresql/extensions for pod {} for {}",
+                    pod_name, coredb_name
+                );
+                return Ok(false);
+            }
+            error!(
+                "Failed to check for {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}:\n{}",
+                extension_name, pod_name, coredb_name, output
+            );
+            Err(Action::requeue(Duration::from_secs(10)))
+        }
+        Err(_) => {
+            error!(
+                "Kube exec error checking for {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}",
+                extension_name, pod_name, coredb_name
+            );
+            Err(Action::requeue(Duration::from_secs(10)))
+        }
+    }
+}
+
 /// handles installing extensions
 #[instrument(skip(ctx, cdb) fields(trace_id))]
 pub async fn install_extensions_to_pod(

--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -431,6 +431,7 @@ pub async fn check_for_so_files(
         return Err(Action::requeue(Duration::from_secs(10)));
     }
 
+    // TODO(ianstanton) The postgres version should be configurable in the future, not hardcoded
     let cmd = vec![
         "ls".to_owned(),
         "/var/lib/postgresql/data/tembo/15/lib".to_owned(),

--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -416,8 +416,8 @@ pub async fn check_for_so_files(
     let coredb_name = cdb.metadata.name.as_deref().unwrap_or_default();
 
     info!(
-        "Checking for .so files in /var/lib/postgresql/data/tembo/15/lib for pod {} for {}",
-        pod_name, coredb_name
+        "Checking for {}.so in filesystem for instance {}",
+        extension_name, coredb_name
     );
 
     let client = ctx.client.clone();
@@ -454,27 +454,27 @@ pub async fn check_for_so_files(
                 // Check if .so files exist in output
                 if output.contains(format!("{}.so", extension_name).as_str()) {
                     info!(
-                        "Found {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}",
-                        extension_name, pod_name, coredb_name
+                        "Found {}.so file in filesystem for instance {}",
+                        extension_name, coredb_name
                     );
                     return Ok(true);
                 }
                 info!(
-                    "No .so files found in /usr/local/lib/postgresql/extensions for pod {} for {}",
-                    pod_name, coredb_name
+                    "No {}.so found in filesystem for instance {}",
+                    extension_name, coredb_name
                 );
                 return Ok(false);
             }
             error!(
-                "Failed to check for {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}:\n{}",
-                extension_name, pod_name, coredb_name, output
+                "Failed to check for {}.so in filesystem for instance {}:\n{}",
+                extension_name, coredb_name, output
             );
             Err(Action::requeue(Duration::from_secs(10)))
         }
         Err(_) => {
             error!(
-                "Kube exec error checking for {}.so file in /usr/local/lib/postgresql/extensions for pod {} for {}",
-                extension_name, pod_name, coredb_name
+                "Kube exec error checking for {}.so file in filesystem for instance for {}",
+                extension_name, coredb_name
             );
             Err(Action::requeue(Duration::from_secs(10)))
         }

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -35,9 +35,12 @@ pub async fn reconcile_extension_toggle_state(
     // Some extensions need to be enabled with LOAD (example: auto_explain). These extensions won't show up in
     // pg_available_extensions, and therefore won't be in all_actually_installed_extensions. We need to check for
     // these extensions and add them to all_actually_installed_extensions so they are handled appropriately.
-    let mut extensions_with_load =
-        check_for_extensions_enabled_with_load(cdb, ctx.clone(), all_actually_installed_extensions.clone())
-            .await?;
+    let mut extensions_with_load = check_for_extensions_enabled_with_load(
+        cdb,
+        ctx.clone(),
+        all_actually_installed_extensions.clone(),
+    )
+    .await?;
     all_actually_installed_extensions.append(&mut extensions_with_load);
 
     let ext_status_updates =

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -423,15 +423,25 @@ async fn check_for_extensions_enabled_with_load(
                     description,
                     locations: vec![],
                 };
-                let location_status = ExtensionInstallLocationStatus {
-                    enabled: Some(true),
-                    database: "postgres".to_string(),
-                    schema: None,
-                    version: None,
-                    error: Some(false),
-                    error_message: None,
-                };
-                extension_status.locations.push(location_status);
+
+                let extensions = cdb.spec.extensions.clone();
+                for desired_extension in extensions {
+                    if desired_extension.name == extension.name {
+                        for desired_location in desired_extension.locations {
+                            let location_status = ExtensionInstallLocationStatus {
+                                enabled: Some(desired_location.enabled.clone()),
+                                database: desired_location.database.clone(),
+                                schema: desired_location.schema.clone(),
+                                version: desired_location.version.clone(),
+                                error: Some(false),
+                                error_message: None,
+                            };
+                            extension_status
+                                .locations
+                                .push(location_status);
+                        }
+                    }
+                }
                 extensions_enabled_with_load.push(extension_status);
             }
             info!("Found {}.so file: {}", extension.name, found);

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -74,6 +74,13 @@ async fn toggle_extensions(
                 Some(expected_library_name) => expected_library_name,
             };
             // Get extensions trunk project name
+
+            // If version is None, error
+            if location_to_toggle.version.is_none() {
+                error!("Version for {} is none. Version should never be none when toggling an extension", extension_to_toggle.name);
+                continue;
+            }
+
             let trunk_project_name =
                 get_trunk_project_for_extension(extension_to_toggle.name.clone()).await?;
             let has_loadable_library = get_loadable_library_name(

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -11,7 +11,8 @@ use kube::runtime::controller::Action;
 use crate::extensions::install::check_for_so_files;
 use crate::extensions::types::TrunkInstall;
 use crate::trunk::{
-    get_loadable_library_name, get_trunk_project_for_extension, is_control_file_absent,
+    get_loadable_library_name, get_trunk_project_description, get_trunk_project_for_extension,
+    is_control_file_absent,
 };
 use crate::{
     apis::coredb_types::CoreDBStatus,
@@ -401,9 +402,18 @@ async fn check_for_extensions_enabled_with_load(
                 check_for_so_files(cdb, ctx.clone(), &*pod_name, extension.name.clone()).await?;
             // If found, add to extensions_with_load
             if found {
+                // Get trunk project description for extension
+                let trunk_project_name =
+                    get_trunk_project_for_extension(extension.name.clone()).await?;
+                let description = get_trunk_project_description(
+                    trunk_project_name.clone().unwrap(),
+                    extension.version.clone().unwrap(),
+                )
+                .await?;
+
                 let mut extension_status = ExtensionStatus {
                     name: extension.name.clone(),
-                    description: None,
+                    description,
                     locations: vec![],
                 };
                 let location_status = ExtensionInstallLocationStatus {

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -436,9 +436,7 @@ async fn check_for_extensions_enabled_with_load(
                                 error: Some(false),
                                 error_message: None,
                             };
-                            extension_status
-                                .locations
-                                .push(location_status);
+                            extension_status.locations.push(location_status);
                         }
                     }
                 }

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, env, time::Duration};
 
 use crate::configmap::apply_configmap;
-use tracing::log::error;
+use tracing::error;
 use utoipa::ToSchema;
 
 const DEFAULT_TRUNK_REGISTRY_DOMAIN: &str = "registry.pgtrunk.io";
@@ -329,7 +329,7 @@ pub async fn get_trunk_project_for_extension(
                 "Failed to get trunk project name for extension {}: {:?}",
                 extension_name, e
             );
-            return Err(Action::requeue(Duration::from_secs(300)));
+            return Err(Action::requeue(Duration::from_secs(3)));
         }
     };
     // Check if the extension name matches a trunk project name
@@ -359,7 +359,7 @@ pub async fn is_control_file_absent(
                     "Failed to get trunk project metadata for version {}: {:?}",
                     version, e
                 );
-                return Err(Action::requeue(Duration::from_secs(300)));
+                return Err(Action::requeue(Duration::from_secs(3)));
             }
         };
     // TODO(ianstanton) This assumes that there is only one extension in the project, but we need to handle the case
@@ -391,7 +391,7 @@ pub async fn get_loadable_library_name(
                 "Failed to get trunk project metadata for version {}: {:?}",
                 version, e
             );
-            return Err(Action::requeue(Duration::from_secs(300)));
+            return Err(Action::requeue(Duration::from_secs(3)));
         }
     };
     // Find the extension in the project metadata
@@ -406,7 +406,7 @@ pub async fn get_loadable_library_name(
                 "Failed to find extension {} in trunk project {} version {}",
                 extension_name, trunk_project, version
             );
-            return Err(Action::requeue(Duration::from_secs(300)));
+            return Err(Action::requeue(Duration::from_secs(3)));
         }
     };
     // Find the loadable library in the extension metadata
@@ -442,7 +442,7 @@ pub async fn get_trunk_project_description(
                 "Failed to get trunk project metadata for version {}: {:?}",
                 version, e
             );
-            return Err(Action::requeue(Duration::from_secs(300)));
+            return Err(Action::requeue(Duration::from_secs(3)));
         }
     };
     Ok(project_metadata.description)

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -233,6 +233,7 @@ pub async fn get_trunk_project_names() -> Result<Vec<String>, TrunkError> {
 }
 
 // Get all metadata entries for a given trunk project
+#[allow(dead_code)]
 async fn get_trunk_project_metadata(
     trunk_project: String,
 ) -> Result<Vec<TrunkProjectMetadata>, TrunkError> {

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2290,7 +2290,6 @@ mod test {
         )
         .await;
 
-
         // Assert psql show pg_available_extensions does not contain auto_explain
         wait_until_psql_contains(
             context.clone(),

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2330,7 +2330,7 @@ mod test {
         )
         .await;
 
-        // Check extension status in CoreDB resource
+        // Check auto_explain and auth_delay and pg_stat_statements are enabled in extension status.
         sleep(Duration::from_secs(10)); //TODO(ianstanton) remove this sleep
         let coredb_resource = coredbs.get(name).await.unwrap();
         let mut found_auto_explain = false;
@@ -2466,7 +2466,7 @@ mod test {
         )
         .await;
 
-        // Check extension status in CoreDB resource
+        // Check auto_explain and auth_delay are disabled in extension status. Check pg_stat_statements is still enabled.
         sleep(Duration::from_secs(10)); //TODO(ianstanton) remove this sleep
         let coredb_resource = coredbs.get(name).await.unwrap();
         let mut found_auto_explain = false;

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2197,7 +2197,7 @@ mod test {
 
     #[tokio::test]
     #[ignore]
-    async fn funtional_test_ext_with_load() {
+    async fn functional_test_ext_with_load() {
         // Initialize the Kubernetes client
         let client = kube_client().await;
         let state = State::default();

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2281,6 +2281,25 @@ mod test {
 
         pod_ready_and_running(pods.clone(), pod_name.clone()).await;
 
+        // Assert psql show shared_preload_libraries contains auto_explain and auth_delay
+        wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "SHOW shared_preload_libraries".to_string(),
+            "auto_explain".to_string(),
+            false,
+        )
+        .await;
+
+        wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "SHOW shared_preload_libraries".to_string(),
+            "auth_delay".to_string(),
+            false,
+        )
+        .await;
+
         // Assert psql show pg_available_extensions contains pg_stat_statements
         wait_until_psql_contains(
             context.clone(),
@@ -2336,6 +2355,25 @@ mod test {
         assert!(found_auto_explain);
         assert!(found_pg_stat_statements);
         assert!(found_auth_delay);
+
+        // Cleanup
+        coredbs.delete(name, &Default::default()).await.unwrap();
+        println!("Waiting for CoreDB to be deleted: {}", &name);
+        let _assert_coredb_deleted = tokio::time::timeout(
+            Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
+            await_condition(coredbs.clone(), name, conditions::is_deleted("")),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "CoreDB {} was not deleted after waiting {} seconds",
+                name, TIMEOUT_SECONDS_COREDB_DELETED
+            )
+        });
+        println!("CoreDB resource deleted {}", name);
+
+        // Delete namespace
+        let _ = delete_namespace(client.clone(), &namespace).await;
     }
 
     #[tokio::test]

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2425,7 +2425,7 @@ mod test {
             "auto_explain".to_string(),
             true,
         )
-            .await;
+        .await;
 
         wait_until_psql_contains(
             context.clone(),
@@ -2434,7 +2434,7 @@ mod test {
             "auth_delay".to_string(),
             true,
         )
-            .await;
+        .await;
 
         // Assert psql show pg_available_extensions contains pg_stat_statements
         wait_until_psql_contains(
@@ -2444,7 +2444,7 @@ mod test {
             "pg_stat_statements".to_string(),
             false,
         )
-            .await;
+        .await;
 
         // Assert psql show pg_available_extensions does not contain auto_explain
         wait_until_psql_contains(
@@ -2454,7 +2454,7 @@ mod test {
             "auto_explain".to_string(),
             true,
         )
-            .await;
+        .await;
 
         // Assert psql show pg_available_extensions does not contain auth_delay
         wait_until_psql_contains(
@@ -2464,7 +2464,7 @@ mod test {
             "auth_delay".to_string(),
             true,
         )
-            .await;
+        .await;
 
         // Check extension status in CoreDB resource
         sleep(Duration::from_secs(10)); //TODO(ianstanton) remove this sleep

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -46,6 +46,7 @@ mod test {
     };
     use rand::Rng;
     use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+    use std::thread::sleep;
     use std::{
         collections::{BTreeMap, BTreeSet},
         ops::Not,
@@ -54,7 +55,6 @@ mod test {
         thread,
         time::Duration,
     };
-    use std::thread::sleep;
 
     use tokio::{io::AsyncReadExt, time::timeout};
 

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2103,7 +2103,7 @@ mod test {
                         "description": "cron",
                         "locations": [{
                             "enabled": true,
-                            "version": "1.5.2",
+                            "version": "1.6.2",
                             "database": "postgres",
                         }],
                     },
@@ -2118,7 +2118,7 @@ mod test {
                 }],
                 "trunk_installs": [{
                         "name": "pg_cron",
-                        "version": "1.5.2",
+                        "version": "1.6.2",
                 },
                 {
                         "name": "citus",
@@ -2902,7 +2902,8 @@ mod test {
                         "locations": [
                             {
                                 "database": "postgres",
-                                "enabled": true
+                                "enabled": true,
+                                "version": "1.4.1"
                             }
                         ]
                     }
@@ -3320,7 +3321,8 @@ mod test {
                         "locations": [
                             {
                                 "database": "postgres",
-                                "enabled": true
+                                "enabled": true,
+                                "version": "1.4.1"
                             }
                         ]
                     }
@@ -3875,7 +3877,10 @@ CREATE EVENT TRIGGER pgrst_watch
                     }
                 }
             }
-            println!("Waiting for runtime_config to be populated with expected values");
+            println!(
+                "Waiting for runtime_config for {} to be populated with expected values",
+                name
+            );
             tokio::time::sleep(Duration::from_secs(5)).await;
         }
 


### PR DESCRIPTION
Some postgres extensions are enabled with `LOAD` or added to `shared_preload_libraries` instead of the traditional `CREATE EXTENSION` command (example: [auto_explain](https://www.postgresql.org/docs/current/auto-explain.html)). This PR adds logic to handle those types of extensions.
- Check if one of these extensions is installed by looking for `<extension_name>.so` in `/var/lib/postgresql/data/tembo/15/lib`
- Fetch trunk project metadata for a given extension
  - Example:
  ```
  [
    {
      "name": "auto_explain",
      "description": "The auto_explain module provides a means for logging execution plans of slow statements automatically, without having to run EXPLAIN by hand.",
      "documentation_link": "https://www.postgresql.org/docs/current/auto-explain.html",
      "repository_link": "https://github.com/postgres/postgres/tree/master/contrib/auto_explain",
      "version": "15.3.0",
      "postgres_versions": [
        15
      ],
      "extensions": [
        {
          "extension_name": "auto_explain",
          "version": "15.3.0",
          "trunk_project_name": "auto_explain",
          "dependencies_extension_names": null,
          "loadable_libraries": [
            {
              "library_name": "auto_explain",
              "requires_restart": true,
              "priority": 2147483647
            }
          ],
          "configurations": null,
          "control_file": {
            "absent": true,
            "content": null
          }
        }
      ],
      "downloads": [
        {
          "link": "https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/auto_explain/auto_explain-pg15-15.3.0.tar.gz",
          "pg_version": 15,
          "platform": "linux/amd64",
          "sha256": "23eb345e8b5892c20f24a51d3c0de97198cde95a17c72426180f6d9b9ad8692b"
        }
      ]
    }
  ]
  ```
- If the extension has no control file && has a loadable library, skip traditional `CREATE EXTENSION` and add to `shared_preload_libraries`