### PR TITLE
add a check for Cluster when applying ScheduledBackup

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.30.1"
+version = "0.30.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
This issue stems from an alert we had this morning where the initial backup for this specific instance wasn't ran.  

We need to make sure that the `ScheduledBackup` that is applied when each instance is created, is only applied after the `Cluster` CR.  If not then the initial backup will not run.

fixes: [TEM-2875](https://linear.app/tembo/issue/TEM-2875/make-sure-cluster-is-placed-before-scheduledbackup)