### PR TITLE
Bugfix: Get appropriate version for trunk project

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.31.0"
+version = "0.31.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -78,7 +78,7 @@ async fn toggle_extensions(
             let trunk_project_name =
                 get_trunk_project_for_extension(extension_to_toggle.name.clone()).await?;
 
-            // Find version for trunk_project_name in cdb.spec.trunk_installs
+            // Get appropriate version for trunk project
             let trunk_project_version = get_trunk_project_version(
                 cdb,
                 trunk_project_name.clone(),
@@ -454,6 +454,7 @@ async fn get_trunk_project_version(
 ) -> Result<Option<String>, Action> {
     let mut trunk_project_version = None;
 
+    // Check if version is provided in cdb.spec.trunk_installs
     for trunk_install in cdb.spec.trunk_installs.clone() {
         if trunk_install.name == trunk_project_name.clone().unwrap() {
             trunk_project_version = trunk_install.version;

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -11,8 +11,9 @@ use kube::runtime::controller::Action;
 use crate::extensions::install::check_for_so_files;
 use crate::extensions::types::TrunkInstall;
 use crate::trunk::{
-    get_loadable_library_name, get_trunk_project_description, get_trunk_project_for_extension,
-    is_control_file_absent,
+    convert_to_semver, get_latest_trunk_project_version, get_loadable_library_name,
+    get_trunk_project_description, get_trunk_project_for_extension,
+    get_trunk_project_metadata_for_version, is_control_file_absent, is_semver,
 };
 use crate::{
     apis::coredb_types::CoreDBStatus,
@@ -78,12 +79,12 @@ async fn toggle_extensions(
                 get_trunk_project_for_extension(extension_to_toggle.name.clone()).await?;
 
             // Find version for trunk_project_name in cdb.spec.trunk_installs
-            let mut trunk_project_version = None;
-            for trunk_install in cdb.spec.trunk_installs.clone() {
-                if trunk_install.name == trunk_project_name.clone().unwrap() {
-                    trunk_project_version = trunk_install.version;
-                }
-            }
+            let trunk_project_version = get_trunk_project_version(
+                cdb,
+                trunk_project_name.clone(),
+                location_to_toggle.clone(),
+            )
+            .await?;
 
             // If version is None, error
             if trunk_project_version.is_none() {
@@ -443,6 +444,61 @@ async fn check_for_extensions_enabled_with_load(
         }
     }
     Ok(extensions_enabled_with_load)
+}
+
+// Get trunk project version
+async fn get_trunk_project_version(
+    cdb: &CoreDB,
+    trunk_project_name: Option<String>,
+    location_to_toggle: types::ExtensionInstallLocation,
+) -> Result<Option<String>, Action> {
+    let mut trunk_project_version = None;
+
+    for trunk_install in cdb.spec.trunk_installs.clone() {
+        if trunk_install.name == trunk_project_name.clone().unwrap() {
+            trunk_project_version = trunk_install.version;
+        }
+    }
+
+    // If trunk_project_version is None && extension version is semver
+    if trunk_project_version.is_none() && is_semver(location_to_toggle.version.clone().unwrap()) {
+        // Check if trunk project with extension version exists
+        let trunk_project_version_exists = get_trunk_project_metadata_for_version(
+            trunk_project_name.clone().unwrap(),
+            location_to_toggle.version.clone().unwrap(),
+        )
+        .await
+        .is_ok();
+        // If trunk project exists for this version, use it
+        if trunk_project_version_exists {
+            trunk_project_version = location_to_toggle.version.clone();
+        }
+        // Otherwise, fall back to latest version
+        else {
+            trunk_project_version =
+                get_latest_trunk_project_version(trunk_project_name.clone().unwrap()).await?;
+        }
+        // If trunk_project_version is None && extension version is NOT semver
+    } else if trunk_project_version.is_none() {
+        // Convert to semver and check if trunk project with semver version exists
+        let semver_version = convert_to_semver(location_to_toggle.version.clone().unwrap());
+        let trunk_project_version_exists = get_trunk_project_metadata_for_version(
+            trunk_project_name.clone().unwrap(),
+            semver_version.clone(),
+        )
+        .await
+        .is_ok();
+        // If trunk project exists for this version, use it
+        if trunk_project_version_exists {
+            trunk_project_version = Some(semver_version);
+        }
+        // Otherwise, fall back to latest version
+        else {
+            trunk_project_version =
+                get_latest_trunk_project_version(trunk_project_name.clone().unwrap()).await?;
+        }
+    }
+    Ok(trunk_project_version)
 }
 
 #[cfg(test)]

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2339,6 +2339,15 @@ mod test {
                         }],
                     },
                     {
+                        "name": "plperl",
+                        "description": "",
+                        "locations": [{
+                            "enabled": true,
+                            "version": "1.0",
+                            "database": "postgres",
+                        }],
+                    },
+                    {
                         "name": "auth_delay",
                         "description": "",
                         "locations": [{

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -2325,7 +2325,16 @@ mod test {
                         "description": "",
                         "locations": [{
                             "enabled": true,
-                            "version": "1.10.0",
+                            "version": "1.10",
+                            "database": "postgres",
+                        }],
+                    },
+                    {
+                        "name": "adminpack",
+                        "description": "",
+                        "locations": [{
+                            "enabled": true,
+                            "version": "2.1",
                             "database": "postgres",
                         }],
                     },
@@ -2349,6 +2358,10 @@ mod test {
                 {
                         "name": "auth_delay",
                         "version": "15.3.0",
+                },
+                {
+                        "name": "adminpack",
+                        "version": "2.1.0",
                 }]
             }
         });


### PR DESCRIPTION
Using extension version to fetch trunk project info can cause an error.
```
2024-01-22T21:27:12.600287Z ERROR reconciling object:reconcile:reconcile: controller::trunk:283: Failed to fetch metadata for trunk project plperl version 1.0 object.ref=CoreDB.v1alpha1.coredb.io/org-demo-inst-test-ext.org-demo-inst-test-ext object.reason=reconciler requested retry trace_id=00000000000000000000000000000000
2024-01-22T21:27:12.600315Z ERROR reconciling object:reconcile:reconcile: controller::trunk:391: Failed to get trunk project metadata for version 1.0: ParsingIssue(Error("No metadata found", line: 0, column: 0)) object.ref=CoreDB.v1alpha1.coredb.io/org-demo-inst-test-ext.org-demo-inst-test-ext object.reason=reconciler requested retry trace_id=00000000000000000000000000000000
```
This can happen when the extension version does not use `semver` (example `1.0`).

This PR adds logic to find the appropriate trunk project version:
- Check if version is provided in `cdb.spec.trunk_installs`
- If it's not && extension version is semver
  - Check if trunk project with extension version exists
  - If it exists, use it
  - Otherwise fall back to latest trunk project version
- If it's not && extension version is NOT semver
  - Convert to semver and check if trunk project with semver version exists
  - If it exists, use it
  - Otherwise fall back to latest trunk project version