### PR TITLE
Populate empty extension location status if necessary

### DIFF
--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.31.1"
+version = "0.31.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -424,8 +424,10 @@ async fn check_for_extensions_enabled_with_load(
                 };
 
                 let extensions = cdb.spec.extensions.clone();
+                let mut found = false;
                 for desired_extension in extensions {
                     if desired_extension.name == extension.name {
+                        found = true;
                         for desired_location in desired_extension.locations {
                             let location_status = ExtensionInstallLocationStatus {
                                 enabled: Some(desired_location.enabled.clone()),
@@ -438,6 +440,19 @@ async fn check_for_extensions_enabled_with_load(
                             extension_status.locations.push(location_status);
                         }
                     }
+                }
+                if !found {
+                    // If trunk installed extension is not in cdb.spec.extensions, we need to set a default location status
+                    info!("Trunk installed extension {} is not in cdb.spec.extensions. Setting default location status.", extension.name);
+                    let location_status = ExtensionInstallLocationStatus {
+                        enabled: Some(false),
+                        database: "postgres".to_string(),
+                        schema: None,
+                        version: None,
+                        error: Some(false),
+                        error_message: None,
+                    };
+                    extension_status.locations.push(location_status);
                 }
                 extensions_enabled_with_load.push(extension_status);
             }


### PR DESCRIPTION
When we install an extension that needs to be enabled with `LOAD` in Tembo Cloud, the `cdb.status.extensions.locations` info is empty. Example with `auto_explain`:
```
status:
  extensions:
  - description: administrative functions for PostgreSQL
    locations:
    - database: app
      enabled: false
      error: false
      schema: public
      version: "2.1"
    - database: postgres
      enabled: true
      error: false
      schema: pg_catalog
      version: "2.1"
    name: adminpack
  - description: The auto_explain module provides a means for logging execution plans
      of slow statements automatically, without having to run EXPLAIN by hand.
    locations: []
    name: auto_explain
```

This PR adds logic to populate default values for this case. 