### PR TITLE
make sure git sha is always a string when rendered in template

### DIFF
--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: 'Helm chart to deploy the tembo-operator'
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.2.3
+version: 0.2.4
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo-stacks

--- a/charts/tembo-operator/templates/deployment-operator.yaml
+++ b/charts/tembo-operator/templates/deployment-operator.yaml
@@ -29,7 +29,7 @@ spec:
         {{- end }}
     spec:
       containers:
-        - image: {{ (index .Values "controller").image.repository }}:{{ tpl (index .Values "controller").image.tag . }}
+        - image: {{ (index .Values "controller").image.repository }}:{{ tpl (printf "%s" (index .Values "controller").image.tag) . }}
           imagePullPolicy: {{ (index .Values "controller").image.pullPolicy }}
           name: tembo-controller
           {{- with (index .Values "controller").extraEnv }}

--- a/charts/tembo-operator/templates/deployment-pod-init.yaml
+++ b/charts/tembo-operator/templates/deployment-pod-init.yaml
@@ -31,7 +31,7 @@ spec:
         {{- end }}
     spec:
       containers:
-        - image: {{ (index .Values "pod-init").image.repository }}:{{ tpl (index .Values "pod-init").image.tag . }}
+        - image: {{ (index .Values "pod-init").image.repository }}:{{ tpl (printf "%s" (index .Values "pod-init").image.tag) . }}
           imagePullPolicy: {{ (index .Values "pod-init").image.pullPolicy }}
           name: pod-init
           env:


### PR DESCRIPTION
Helm will still render values that are supposed to be `string` as `int` if not rendered correctly. 