### PR TITLE
Switch from actions-rs to dtolnay toolchain

### DIFF
--- a/.github/actions/publish-crate/action.yml
+++ b/.github/actions/publish-crate/action.yml
@@ -11,11 +11,11 @@ inputs:
   fail-if-version-published:
     description: "If the version is already published, should we fail, or ignore? By default, ignore."
     required: false
-    default: false
+    default: "false"
   dry-run:
     description: "Use --dry-run flag on cargo publish?"
     required: false
-    default: false
+    default: "false"
   toolchain:
     description: "Which Rust toolchain to use?"
     default: "stable"
@@ -24,7 +24,7 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: ${{ inputs.toolchain }}
     - name: Install TOML parser


### PR DESCRIPTION
For the toolchain action, because actions-rs/toolchain has had no changes in 4 years, uses the deprecated `set-output` function, and was archived in October. Follow the findings of RustCrypto/actions#17 and switch to dtolnay/rust-toolchain.

Also fix the `default`s in inputs; the values are supposed to be strings.