### PR TITLE
add repository field for stacks, clean up clippy wanrings

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.31.7"
+version = "0.32.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.31.7"
+version = "0.32.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -389,7 +389,7 @@ pub struct CoreDBSpec {
     /// please visit our [tembo-images](https://github.com/tembo-io/tembo-images) repository.
     ///
     /// **Default**: quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e
-    #[serde(default = "defaults::default_image")]
+    #[serde(default = "defaults::default_image_uri")]
     pub image: String,
 
     /// **DEPRECATED** The postgres-exporter image you want to use for the postgres-exporter deployment.

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -46,7 +46,7 @@ use crate::{
     },
     config::Config,
     configmap::custom_metrics_configmap_settings,
-    defaults::{default_image, default_llm_image},
+    defaults::{default_dw_image_uri, default_image_uri, default_llm_image_uri},
     errors::ValueError,
     is_postgres_ready, patch_cdb_status_merge,
     postgres_exporter::EXPORTER_CONFIGMAP_PREFIX,
@@ -600,8 +600,9 @@ pub fn cnpg_cluster_from_cdb(
     // Check if the cdb.spec.image is set, if not then figure out which image to use.
     let image = if cdb.spec.image.is_empty() {
         match cdb.spec.stack.as_ref().map(|s| s.name.to_lowercase()) {
-            Some(ref name) if name == "machinelearning" => default_llm_image(),
-            _ => default_image(),
+            Some(ref name) if name == "machinelearning" => default_llm_image_uri(),
+            Some(ref name) if name == "datawarehouse" => default_dw_image_uri(),
+            _ => default_image_uri(),
         }
     } else {
         cdb.spec.image.clone()

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -43,12 +43,38 @@ pub fn default_port() -> i32 {
     5432
 }
 
+pub fn default_repository() -> String {
+    "quay.io/tembo".to_owned()
+}
+
 pub fn default_image() -> String {
-    "quay.io/tembo/standard-cnpg:15.3.0-1-0c19c7e".to_owned()
+    "standard-cnpg:15.3.0-1-0c19c7e".to_owned()
 }
 
 pub fn default_llm_image() -> String {
-    "quay.io/tembo/ml-cnpg:15.3.0-1-63e32a1".to_owned()
+    "ml-cnpg:15.3.0-1-63e32a1".to_owned()
+}
+
+pub fn default_dw_image() -> String {
+    "dw-cnpg:15.3.0-1-839d08e".to_owned()
+}
+
+pub fn default_image_uri() -> String {
+    let repo = default_repository();
+    let image = default_image();
+    format!("{}/{}", repo, image)
+}
+
+pub fn default_llm_image_uri() -> String {
+    let repo = default_repository();
+    let image = default_llm_image();
+    format!("{}/{}", repo, image)
+}
+
+pub fn default_dw_image_uri() -> String {
+    let repo = default_repository();
+    let image = default_dw_image();
+    format!("{}/{}", repo, image)
 }
 
 pub fn default_storage() -> Quantity {

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -405,7 +405,7 @@ async fn check_for_extensions_enabled_with_load(
         for extension in trunk_installed_extensions_not_in_all_actually_installed_extensions.clone()
         {
             let found =
-                check_for_so_files(cdb, ctx.clone(), &*pod_name, extension.name.clone()).await?;
+                check_for_so_files(cdb, ctx.clone(), &pod_name, extension.name.clone()).await?;
             // If found, add to extensions_with_load
             if found {
                 // Get trunk project description for extension
@@ -430,7 +430,7 @@ async fn check_for_extensions_enabled_with_load(
                         found = true;
                         for desired_location in desired_extension.locations {
                             let location_status = ExtensionInstallLocationStatus {
-                                enabled: Some(desired_location.enabled.clone()),
+                                enabled: Some(desired_location.enabled),
                                 database: desired_location.database.clone(),
                                 schema: desired_location.schema.clone(),
                                 version: desired_location.version.clone(),

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -1,6 +1,7 @@
 name: API
 description: Tembo Stack with REST and graphQL interfaces.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - image: postgrest/postgrest:v12.0.0

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -1,6 +1,7 @@
 name: DataWarehouse
 description: A Postgres instance equipped with configuration and extensions for building a data warehouse on Postgres.
-image: "quay.io/tembo/dw-cnpg:15.3.0-1-46c8b6f"
+repository: "quay.io/tembo"
+image: "dw-cnpg:15.3.0-1-46c8b6f"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -1,6 +1,7 @@
 name: Geospatial
 description: Postgres for geospatial workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -1,6 +1,7 @@
 name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
-image: "quay.io/tembo/ml-cnpg:15.3.0-1-46c8b6f"
+repository: "quay.io/tembo"
+image: "ml-cnpg:15.3.0-1-46c8b6f"
 stack_version: 0.3.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -1,6 +1,7 @@
 name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.3.0
 appServices:
   - name: mq-api

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -1,6 +1,7 @@
 name: MongoAlternative
 description: Document-facing workloads on Postgres.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - name: fdb-api

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -1,6 +1,7 @@
 name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -1,6 +1,7 @@
 name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -1,6 +1,7 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -1,6 +1,7 @@
 name: VectorDB
 description: A Tembo Postgres Stack configured to support vector data types, storage, and operations.
-image: "quay.io/tembo/standard-cnpg:15.3.0-1-795fc99"
+repository: "quay.io/tembo"
+image: "standard-cnpg:15.3.0-1-795fc99"
 stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:7dc6329

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -1,7 +1,7 @@
 use crate::{
     apis::postgres_parameters::PgConfig,
     app_service::types::AppService,
-    defaults::default_image,
+    defaults::{default_image, default_repository},
     extensions::types::{Extension, TrunkInstall},
     postgres_exporter::QueryConfig,
     stacks::config_engines::{
@@ -69,6 +69,8 @@ pub struct Stack {
     pub name: String,
     pub compute_templates: Option<Vec<ComputeTemplate>>,
     pub description: Option<String>,
+    #[serde(default = "default_stack_repository")]
+    pub repository: Option<String>,
     #[serde(default = "default_stack_image")]
     pub image: Option<String>,
     pub stack_version: Option<String>,
@@ -96,6 +98,10 @@ impl Stack {
             None => Some(standard_config_engine(self)),
         }
     }
+}
+
+fn default_stack_repository() -> Option<String> {
+    Some(default_repository())
 }
 
 fn default_stack_image() -> Option<String> {

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -277,7 +277,7 @@ pub async fn get_trunk_project_metadata_for_version(
         let response_body = response.text().await?;
         let project_metadata: Vec<TrunkProjectMetadata> = serde_json::from_str(&response_body)?;
         // There will only be one index here, so we can safely assume index 0
-        let project_metadata = match project_metadata.get(0) {
+        let project_metadata = match project_metadata.first() {
             Some(project_metadata) => project_metadata,
             None => {
                 error!(
@@ -367,7 +367,7 @@ pub async fn is_control_file_absent(
     //  where there are multiple extensions
     let control_file_absent = project_metadata
         .extensions
-        .get(0)
+        .first()
         .unwrap()
         .control_file
         .absent;
@@ -411,18 +411,11 @@ pub async fn get_loadable_library_name(
         }
     };
     // Find the loadable library in the extension metadata
-    let loadable_library_name = match extension_metadata.loadable_libraries {
-        Some(ref loadable_libraries) => {
-            let loadable_library = loadable_libraries
-                .iter()
-                .find(|l| l.requires_restart == true);
-            match loadable_library {
-                Some(loadable_library) => Some(loadable_library.library_name.clone()),
-                None => None,
-            }
-        }
-        None => None,
-    };
+    let loadable_library_name = extension_metadata
+        .loadable_libraries
+        .as_ref()
+        .and_then(|loadable_libraries| loadable_libraries.iter().find(|l| l.requires_restart))
+        .map(|loadable_library| loadable_library.library_name.clone());
     Ok(loadable_library_name)
 }
 
@@ -496,8 +489,8 @@ pub fn convert_to_semver(version: String) -> String {
 fn sort_semver(versions: Vec<String>) -> Vec<String> {
     let mut versions = versions;
     versions.sort_by(|a, b| {
-        let a = semver::Version::parse(&a).unwrap();
-        let b = semver::Version::parse(&b).unwrap();
+        let a = semver::Version::parse(a).unwrap();
+        let b = semver::Version::parse(b).unwrap();
         a.cmp(&b)
     });
     versions
@@ -550,17 +543,17 @@ mod tests {
         let extension_name = "auto_explain".to_string();
         let result = extension_name_matches_trunk_project(extension_name).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
 
         let extension_name = "pgml".to_string();
         let result = extension_name_matches_trunk_project(extension_name).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
 
         let extension_name = "vector".to_string();
         let result = extension_name_matches_trunk_project(extension_name).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[tokio::test]
@@ -592,7 +585,7 @@ mod tests {
         let version = "15.3.0".to_string();
         let result = is_control_file_absent(trunk_project, version).await;
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), true);
+        assert!(result.unwrap());
     }
 
     #[tokio::test]
@@ -618,11 +611,11 @@ mod tests {
     fn test_is_semver() {
         let version = "1.2.3".to_string();
         let result = is_semver(version);
-        assert_eq!(result, true);
+        assert!(result);
 
         let version = "1.2".to_string();
         let result = is_semver(version);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -46,7 +46,6 @@ mod test {
     };
     use rand::Rng;
     use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
-    use std::thread::sleep;
     use std::{
         collections::{BTreeMap, BTreeSet},
         ops::Not,
@@ -613,19 +612,17 @@ mod test {
                                 attempt, max_retries, name, extension
                             );
                         }
+                    } else if has_extension {
+                        println!(
+                            "CoreDB {} has extension {} enabled in status",
+                            name, extension
+                        );
+                        return Ok(());
                     } else {
-                        if has_extension {
-                            println!(
-                                "CoreDB {} has extension {} enabled in status",
-                                name, extension
-                            );
-                            return Ok(());
-                        } else {
-                            println!(
-                                "Attempt {}/{}: CoreDB {} has extension {} disabled in status",
-                                attempt, max_retries, name, extension
-                            );
-                        }
+                        println!(
+                            "Attempt {}/{}: CoreDB {} has extension {} disabled in status",
+                            attempt, max_retries, name, extension
+                        );
                     }
                 }
                 Err(e) => {
@@ -2332,7 +2329,7 @@ mod test {
         });
         let params = PatchParams::apply("tembo-integration-test");
         let patch = Patch::Apply(&coredb_json);
-        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+        let _coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
 
         // Wait for CNPG Pod to be created
         let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
@@ -2346,7 +2343,7 @@ mod test {
         // Check status.extensions.locations is not empty
         let coredb_resource = coredbs.get(name).await.unwrap();
         for extension in coredb_resource.status.unwrap().extensions.unwrap() {
-            assert!(extension.locations.len() > 0);
+            assert!(!extension.locations.is_empty());
         }
 
         // Update CoreDB resource to enable extensions


### PR DESCRIPTION
* Add new field `repository` to the `Stack` struct to allow setting a different repository if wanted.
  * Update stack templates

* Clean up clippy warnings

fixes: [TEM-2538](https://linear.app/tembo/issue/TEM-2538/faster-image-pulls)