### PR TITLE
adds `restapi` support for app_services for local that uses postgrest under the hood

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3826,6 +3826,7 @@ dependencies = [
  "hyper",
  "jsonwebtoken",
  "jwt",
+ "k8s-openapi",
  "log",
  "mockall",
  "openssl",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"
@@ -59,6 +59,7 @@ cli-table = "0.4.7"
 tiny-gradient = "0.1.0"
 urlencoding = "2.1.3"
 spinoff = "0.8.0"
+k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false }
 
 [target.aarch64-unknown-linux-musl.dependencies]
 openssl = { version = "0.10", features = ["vendored"] }

--- a/tembo-cli/examples/multiple-instances/tembo.toml
+++ b/tembo-cli/examples/multiple-instances/tembo.toml
@@ -14,3 +14,5 @@ storage = "50Gi"
 replicas = 1
 stack_type = "OLTP"
 
+[instance-2.app_services.restapi]
+restapi = { }

--- a/tembo-cli/src/cli/context.rs
+++ b/tembo-cli/src/cli/context.rs
@@ -126,8 +126,8 @@ pub fn list_credential_profiles() -> Result<Vec<Profile>, anyhow::Error> {
     let contents = fs::read_to_string(&filename)
         .map_err(|err| anyhow!("Error reading file {filename}: {err}"))?;
 
-    let credential: Credential =
-        toml::from_str(&contents).map_err(|err| anyhow!("Issue with the format of the TOML file {filename}: {err}"))?;
+    let credential: Credential = toml::from_str(&contents)
+        .map_err(|err| anyhow!("Issue with the format of the TOML file {filename}: {err}"))?;
 
     Ok(credential.profile)
 }

--- a/tembo-cli/src/cli/tembo_config.rs
+++ b/tembo-cli/src/cli/tembo_config.rs
@@ -110,12 +110,10 @@ pub struct Probe {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub enum Middleware {
-    #[serde(rename = "customRequestHeaders")]
     CustomRequestHeaders(HeaderConfig),
-    #[serde(rename = "stripPrefix")]
     StripPrefix(StripPrefixConfig),
-    #[serde(rename = "replacePathRegex")]
     ReplacePathRegex(ReplacePathRegexConfig),
 }
 
@@ -143,18 +141,14 @@ pub struct ReplacePathRegexConfigType {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Routing {
     pub port: u16,
-    #[serde(rename = "ingressPath")]
     pub ingress_path: Option<String>,
 
     /// provide name of the middleware resources to apply to this route
     pub middlewares: Option<Vec<String>>,
-    #[serde(rename = "entryPoints")]
-    //#[serde(default = "default_entry_points")]
     pub entry_points: Option<Vec<String>>,
-    #[serde(rename = "ingressType")]
-    //#[serde(default = "default_ingress_type")]
     pub ingress_type: Option<IngressType>,
 }
 

--- a/tembo-cli/src/cli/tembo_config.rs
+++ b/tembo-cli/src/cli/tembo_config.rs
@@ -1,6 +1,7 @@
-use k8s_openapi::api::core::v1::{ResourceRequirements, Volume, VolumeMount};
+use controller::app_service::types::{AppService, EnvVar};
+use k8s_openapi::api::core::v1::ResourceRequirements;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use toml::Value;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -54,116 +55,6 @@ pub enum AppType {
 pub struct AppConfig {
     pub env: Option<Vec<EnvVar>>,
     pub resources: Option<ResourceRequirements>,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct AppService {
-    pub name: String,
-
-    pub image: String,
-
-    pub args: Option<Vec<String>>,
-
-    pub command: Option<Vec<String>>,
-
-    pub env: Option<Vec<EnvVar>>,
-
-    pub resources: ResourceRequirements,
-
-    pub probes: Option<Probes>,
-
-    pub middlewares: Option<Vec<Middleware>>,
-
-    pub routing: Option<Vec<Routing>>,
-
-    pub storage: Option<StorageConfig>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct EnvVar {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-    #[serde(rename = "valueFromPlatform", skip_serializing_if = "Option::is_none")]
-    pub value_from_platform: Option<EnvVarRef>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum EnvVarRef {
-    ReadOnlyConnection,
-    ReadWriteConnection,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Probes {
-    pub readiness: Probe,
-    pub liveness: Probe,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Probe {
-    pub path: String,
-    pub port: String,
-    // this should never be negative
-    #[serde(rename = "initialDelaySeconds")]
-    pub initial_delay_seconds: u32,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub enum Middleware {
-    CustomRequestHeaders(HeaderConfig),
-    StripPrefix(StripPrefixConfig),
-    ReplacePathRegex(ReplacePathRegexConfig),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct HeaderConfig {
-    pub name: String,
-    pub config: BTreeMap<String, String>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct StripPrefixConfig {
-    pub name: String,
-    pub config: Vec<String>,
-}
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ReplacePathRegexConfig {
-    pub name: String,
-    pub config: ReplacePathRegexConfigType,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct ReplacePathRegexConfigType {
-    pub regex: String,
-    pub replacement: String,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Routing {
-    pub port: u16,
-    pub ingress_path: Option<String>,
-
-    /// provide name of the middleware resources to apply to this route
-    pub middlewares: Option<Vec<String>>,
-    pub entry_points: Option<Vec<String>>,
-    pub ingress_type: Option<IngressType>,
-}
-
-#[allow(non_camel_case_types)]
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub enum IngressType {
-    http,
-    tcp,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct StorageConfig {
-    pub volumes: Option<Vec<Volume>>,
-    #[serde(rename = "volumeMounts")]
-    pub volume_mounts: Option<Vec<VolumeMount>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -561,6 +561,7 @@ fn merge_settings(base: &InstanceSettings, overlay: OverlayInstanceSettings) -> 
             .postgres_configurations
             .or_else(|| base.postgres_configurations.clone()),
         extensions: overlay.extensions.or_else(|| base.extensions.clone()),
+        app_services: None,
         extra_domains_rw: overlay
             .extra_domains_rw
             .or_else(|| base.extra_domains_rw.clone()),

--- a/tembo-cli/tembo/docker-compose.yml.template
+++ b/tembo-cli/tembo/docker-compose.yml.template
@@ -17,6 +17,27 @@ services:
       - "traefik.tcp.routers.{{instance.instance_name}}.entrypoints=postgresql"
       - "traefik.tcp.routers.{{instance.instance_name}}.tls.passthrough=true"
       - "traefik.tcp.services.{{instance.instance_name}}.loadbalancer.server.port=5432"
+
+  {% if instance.app_services.restapi %}
+  {{instance.instance_name}}-postgrest:
+    image: postgrest/postgrest:v10.0.0
+    environment:
+      PGRST_DB_URI: "postgresql://postgres:postgres@{{instance.instance_name}}:5432/postgres"
+      PGRST_DB_SCHEMA: "public, graphql"
+      PGRST_DB_ANON_ROLE: "postgres"
+      PGRST_LOG_LEVEL: "info"
+    networks:
+      - tembo
+    labels:
+      - "traefik.enable=true"
+      # The settings here depends on the app service settings
+      - "traefik.http.routers.{{instance.instance_name}}-postgrest.rule=Host(`{{instance.instance_name}}.local.tembo.io`) && (PathPrefix(`/rest/v1`) || PathPrefix(`/graphql/v1`))"
+      # in cloud, this is websecure instead of just web
+      - "traefik.http.routers.{{instance.instance_name}}-postgrest.entrypoints=web"
+      - "traefik.http.services.{{instance.instance_name}}-postgrest.loadbalancer.server.port=3000"
+      - "traefik.http.middlewares.postgrest-stripprefix.stripprefix.prefixes=/rest/v1, /graphql/v1"
+      - "traefik.http.routers.postgrest.middlewares=postgrest-stripprefix"
+  {% endif %}
 {% endfor %}
 
   traefik:

--- a/tembo-cli/tembo/docker-compose.yml.template
+++ b/tembo-cli/tembo/docker-compose.yml.template
@@ -31,12 +31,13 @@ services:
     labels:
       - "traefik.enable=true"
       # The settings here depends on the app service settings
-      - "traefik.http.routers.{{instance.instance_name}}-postgrest.rule=Host(`{{instance.instance_name}}.local.tembo.io`) && (PathPrefix(`/rest/v1`) || PathPrefix(`/graphql/v1`))"
+      - "traefik.http.routers.{{instance.instance_name}}-postgrest.rule=Host(`{{instance.instance_name}}.local.tembo.io`)"
+      # && (PathPrefix(`/rest/v1`) || PathPrefix(`/graphql/v1`))"
       # in cloud, this is websecure instead of just web
       - "traefik.http.routers.{{instance.instance_name}}-postgrest.entrypoints=web"
       - "traefik.http.services.{{instance.instance_name}}-postgrest.loadbalancer.server.port=3000"
-      - "traefik.http.middlewares.postgrest-stripprefix.stripprefix.prefixes=/rest/v1, /graphql/v1"
-      - "traefik.http.routers.postgrest.middlewares=postgrest-stripprefix"
+      # - "traefik.http.middlewares.postgrest-stripprefix.stripprefix.prefixes=/rest/v1,/graphql/v1"
+      # - "traefik.http.routers.postgrest.middlewares=postgrest-stripprefix"
   {% endif %}
 {% endfor %}
 

--- a/tembo-cli/tests/integration_tests.rs
+++ b/tembo-cli/tests/integration_tests.rs
@@ -1,6 +1,7 @@
 use assert_cmd::prelude::*; // Add methods on commands
 
 use colorful::core::StrMarker;
+use curl::easy::Easy;
 use predicates::prelude::*;
 use sqlx::postgres::PgConnectOptions;
 use std::env;
@@ -115,6 +116,9 @@ async fn data_warehouse() -> Result<(), Box<dyn Error>> {
 
 #[tokio::test]
 async fn multiple_instances() -> Result<(), Box<dyn Error>> {
+    let instance1_name = "instance-1";
+    let instance2_name = "instance-2";
+
     let root_dir = env!("CARGO_MANIFEST_DIR");
     let test_dir = PathBuf::from(root_dir)
         .join("examples")
@@ -144,8 +148,36 @@ async fn multiple_instances() -> Result<(), Box<dyn Error>> {
     sleep(Duration::from_secs(5));
 
     // check can connect
-    assert_can_connect("instance-1".to_string()).await?;
-    assert_can_connect("instance-2".to_string()).await?;
+    assert_can_connect(instance1_name.to_string()).await?;
+    assert_can_connect(instance2_name.to_string()).await?;
+
+    execute_sql(
+        instance2_name.to_string(),
+        "create table public.todos (id serial primary key,
+            done boolean not null default false,
+            task text not null,
+            due timestamptz
+          );"
+        .to_string(),
+    )
+    .await?;
+
+    execute_sql(
+        instance2_name.to_string(),
+        "insert into public.todos (task) values
+        ('finish tutorial 0'), ('pat self on back');"
+            .to_string(),
+    )
+    .await?;
+
+    let mut easy = Easy::new();
+    easy.url(&format!(
+        "http://{}.local.tembo.io:8000/todos",
+        instance2_name.to_string()
+    ))
+    .unwrap();
+    easy.perform().unwrap();
+    assert_eq!(easy.response_code().unwrap(), 200);
 
     // tembo delete
     let mut cmd = Command::cargo_bin(CARGO_BIN)?;
@@ -153,8 +185,8 @@ async fn multiple_instances() -> Result<(), Box<dyn Error>> {
     let _ = cmd.ok();
 
     // check can't connect
-    assert!(assert_can_connect("instance-1".to_str()).await.is_err());
-    assert!(assert_can_connect("instance-2".to_str()).await.is_err());
+    assert!(assert_can_connect(instance1_name.to_str()).await.is_err());
+    assert!(assert_can_connect(instance2_name.to_str()).await.is_err());
 
     Ok(())
 }
@@ -180,6 +212,28 @@ async fn get_output_from_sql(instance_name: String, sql: String) -> Result<Strin
     println!("{}", result.0);
 
     Ok(result.0.to_string())
+}
+
+async fn execute_sql(instance_name: String, sql: String) -> Result<(), Box<dyn Error>> {
+    // Configure SQLx connection options
+    let connect_options = PgConnectOptions::new()
+        .username("postgres")
+        .password("postgres")
+        .host(&format!("{}.local.tembo.io", instance_name))
+        .database("postgres");
+
+    // Connect to the database
+    let pool = sqlx::PgPool::connect_with(connect_options).await?;
+
+    // Simple query
+    sqlx::query(&sql).fetch_optional(&pool).await?;
+
+    println!(
+        "Successfully connected to the database: {}",
+        &format!("{}.local.tembo.io", instance_name)
+    );
+
+    Ok(())
 }
 
 async fn assert_can_connect(instance_name: String) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
adds `restapi` support for app_services for local that uses postgrest under the hood

TODO:

* Add support for `app_services` for cloud
* Add support for other AppTypes for local

I'm able to spin up the `traefik` & `postgrest` containers and also hit a table in one of the instances using a postgrest endpoint