### PR TITLE
Add single-instance example for CLI init

### DIFF
--- a/tembo-cli/examples/single-instance/tembo.toml
+++ b/tembo-cli/examples/single-instance/tembo.toml
@@ -1,0 +1,34 @@
+# Tembo.toml configuration file version
+# version = "1.0.0"
+
+# Default settings for instances
+[defaults]
+environment = "dev"
+instance_name = "test-via-cli-35"
+cpu = "1"
+memory = "2Gi"
+storage = "10Gi"
+replicas = 1
+stack_type = "Standard"
+
+[defaults.postgres_configurations]
+shared_preload_libraries = 'pg_stat_statements'
+statement_timeout = 60
+pg_partman_bgw.dbname = 'postgres'
+pg_partman_bgw.interval = "60"
+pg_partman_bgw.role = 'postgres'
+
+[defaults.extensions.pg_jsonschema]
+enabled = true
+trunk_project = "pg_jsonschema"
+trunk_project_version = "0.1.4"
+
+[defaults.extensions.pgmq]
+enabled = true
+trunk_project = "pgmq"
+trunk_project_version = "0.33.3"
+
+[defaults.extensions.pg_partman]
+enabled = true
+trunk_project = "pg_partman"
+trunk_project_version = "4.7.4"


### PR DESCRIPTION
The `tembo init` command relies on https://raw.githubusercontent.com/tembo-io/tembo/main/tembo-cli/examples/single-instance/tembo.toml, which was removed in this PR: 
- https://github.com/tembo-io/tembo/pull/487

Now `tembo init` produces a `tembo.toml` file with contents `404: Not Found`. This PR re-adds the file so it can be used for `tembo init`.