### PR TITLE
conductor/stacks: set images to use for Pg14 and Pg16

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: 'Helm chart to deploy the tembo-operator'
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.2.5
+version: 0.2.6
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo-stacks

--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -1591,7 +1591,7 @@ spec:
                 nullable: true
                 type: array
               image:
-                default: quay.io/tembo/standard-cnpg:15.3.0-1-3d9a853
+                default: quay.io/tembo/standard-cnpg:15-a0a5ab5
                 description: |-
                   The Postgres image to use for the CoreDB instance deployment. This should be a valid Postgres image that is compatible with the [https://tembo.io](https://tembo.io) platform. For more information please visit our [tembo-images](https://github.com/tembo-io/tembo-images) repository.
 

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -50,9 +50,7 @@ pub fn default_repository() -> String {
 
 pub fn default_images() -> ImagePerPgVersion {
     // Note: this will recurse infinitely if standard.yaml doesn't have `images` set
-    STANDARD
-        .images
-        .clone()
+    STANDARD.images.clone()
 }
 
 pub fn default_llm_image() -> String {

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     cloudnativepg::poolers::{PoolerPgbouncerPoolMode, PoolerTemplateSpecContainersResources},
     extensions::types::{Extension, TrunkInstall},
-    stacks::{DATAWAREHOUSE, ML, STANDARD},
+    stacks::{types::ImagePerPgVersion, DATAWAREHOUSE, ML, STANDARD},
 };
 
 pub fn default_replicas() -> i32 {
@@ -48,25 +48,26 @@ pub fn default_repository() -> String {
     "quay.io/tembo".to_owned()
 }
 
-pub fn default_image() -> String {
+pub fn default_images() -> ImagePerPgVersion {
+    // Note: this will recurse infinitely if standard.yaml doesn't have `images` set
     STANDARD
-        .image
+        .images
         .clone()
-        .expect("Standard or default image not found")
 }
 
 pub fn default_llm_image() -> String {
-    ML.image.clone().expect("ML image not found")
+    ML.images.pg15.clone()
 }
 
 pub fn default_dw_image() -> String {
-    DATAWAREHOUSE.image.clone().expect("DW image not found")
+    DATAWAREHOUSE.images.pg15.clone()
 }
 
 pub fn default_image_uri() -> String {
     let repo = default_repository();
-    let image = default_image();
-    format!("{}/{}", repo, image)
+    let image = default_images();
+    let image_for_pg_15 = image.pg15;
+    format!("{}/{}", repo, image_for_pg_15)
 }
 
 pub fn default_llm_image_uri() -> String {

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -3,7 +3,7 @@ description: Tembo Stack with REST and graphQL interfaces.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -1,5 +1,6 @@
 name: API
 description: Tembo Stack with REST and graphQL interfaces.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -2,9 +2,9 @@ name: API
 description: Tembo Stack with REST and graphQL interfaces.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:
   - image: postgrest/postgrest:v12.0.0

--- a/tembo-operator/src/stacks/templates/api.yaml
+++ b/tembo-operator/src/stacks/templates/api.yaml
@@ -1,7 +1,10 @@
 name: API
 description: Tembo Stack with REST and graphQL interfaces.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 appServices:
   - image: postgrest/postgrest:v12.0.0

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -1,7 +1,10 @@
 name: DataWarehouse
 description: A Postgres instance equipped with configuration and extensions for building a data warehouse on Postgres.
-repository: "quay.io/tembo"
-image: "dw-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "dw-cnpg:pg14-f1721c2"
+  15: "dw-cnpg:15.3.0-1-3d9a853"
+  16: "dw-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -2,9 +2,9 @@ name: DataWarehouse
 description: A Postgres instance equipped with configuration and extensions for building a data warehouse on Postgres.
 organization: tembo
 images:
-  14: "dw-cnpg:pg14-f1721c2"
+  14: "dw-cnpg:14-a0a5ab5"
   15: "dw-cnpg:15.3.0-1-3d9a853"
-  16: "dw-cnpg:pg16-f1721c2"
+  16: "dw-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -1,5 +1,6 @@
 name: DataWarehouse
 description: A Postgres instance equipped with configuration and extensions for building a data warehouse on Postgres.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "dw-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/data_warehouse.yaml
+++ b/tembo-operator/src/stacks/templates/data_warehouse.yaml
@@ -4,7 +4,7 @@ repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "dw-cnpg:14-a0a5ab5"
-  15: "dw-cnpg:15.3.0-1-3d9a853"
+  15: "dw-cnpg:15-a0a5ab5"
   16: "dw-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -3,7 +3,7 @@ description: Postgres for geospatial workloads.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -1,5 +1,6 @@
 name: Geospatial
 description: Postgres for geospatial workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -2,9 +2,9 @@ name: Geospatial
 description: Postgres for geospatial workloads.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/gis.yaml
+++ b/tembo-operator/src/stacks/templates/gis.yaml
@@ -1,7 +1,10 @@
 name: Geospatial
 description: Postgres for geospatial workloads.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -1,7 +1,10 @@
 name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
-repository: "quay.io/tembo"
-image: "ml-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "ml-cnpg:pg14-f1721c2"
+  15: "ml-cnpg:15.3.0-1-3d9a853"
+  16: "ml-cnpg:pg16-f1721c2"
 stack_version: 0.3.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -3,7 +3,7 @@ description: A Postgres instance equipped with machine learning extensions and o
 organization: tembo
 images:
   14: "ml-cnpg:14-a0a5ab5"
-  15: "ml-cnpg:15.3.0-1-3d9a853"
+  15: "ml-cnpg:15-a0a5ab5"
   16: "ml-cnpg:16-a0a5ab5"
 stack_version: 0.3.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -1,5 +1,6 @@
 name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "ml-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/machine_learning.yaml
+++ b/tembo-operator/src/stacks/templates/machine_learning.yaml
@@ -2,9 +2,9 @@ name: MachineLearning
 description: A Postgres instance equipped with machine learning extensions and optimized for machine learning workloads.
 organization: tembo
 images:
-  14: "ml-cnpg:pg14-f1721c2"
+  14: "ml-cnpg:14-a0a5ab5"
   15: "ml-cnpg:15.3.0-1-3d9a853"
-  16: "ml-cnpg:pg16-f1721c2"
+  16: "ml-cnpg:16-a0a5ab5"
 stack_version: 0.3.0
 compute_templates:
   - cpu: 2

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -1,5 +1,6 @@
 name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -2,9 +2,9 @@ name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.3.0
 appServices:
   - name: mq-api

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -3,7 +3,7 @@ description: A Tembo Postgres Stack optimized for Message Queue workloads.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.3.0
 appServices:

--- a/tembo-operator/src/stacks/templates/message_queue.yaml
+++ b/tembo-operator/src/stacks/templates/message_queue.yaml
@@ -1,7 +1,10 @@
 name: MessageQueue
 description: A Tembo Postgres Stack optimized for Message Queue workloads.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.3.0
 appServices:
   - name: mq-api

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -3,7 +3,7 @@ description: Document-facing workloads on Postgres.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -2,9 +2,9 @@ name: MongoAlternative
 description: Document-facing workloads on Postgres.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:
   - name: fdb-api

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -1,7 +1,10 @@
 name: MongoAlternative
 description: Document-facing workloads on Postgres.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 appServices:
   - name: fdb-api

--- a/tembo-operator/src/stacks/templates/mongo_alternative.yaml
+++ b/tembo-operator/src/stacks/templates/mongo_alternative.yaml
@@ -1,5 +1,6 @@
 name: MongoAlternative
 description: Document-facing workloads on Postgres.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -3,7 +3,7 @@ description: A Postgres instance equipped with configuration and extensions for 
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -1,7 +1,10 @@
 name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -1,5 +1,6 @@
 name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/olap.yaml
+++ b/tembo-operator/src/stacks/templates/olap.yaml
@@ -2,9 +2,9 @@ name: OLAP
 description: A Postgres instance equipped with configuration and extensions for OLAP workloads.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -1,5 +1,6 @@
 name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -3,7 +3,7 @@ description: A Postgres instance optimized for OLTP workloads.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -2,9 +2,9 @@ name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/oltp.yaml
+++ b/tembo-operator/src/stacks/templates/oltp.yaml
@@ -1,7 +1,10 @@
 name: OLTP
 description: A Postgres instance optimized for OLTP workloads.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -3,7 +3,7 @@ description: A balanced Postgres instance optimized for OLTP workloads.
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -1,7 +1,10 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -2,9 +2,9 @@ name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 compute_templates:
   - cpu: 0.25

--- a/tembo-operator/src/stacks/templates/standard.yaml
+++ b/tembo-operator/src/stacks/templates/standard.yaml
@@ -1,5 +1,6 @@
 name: Standard
 description: A balanced Postgres instance optimized for OLTP workloads.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -2,9 +2,9 @@ name: VectorDB
 description: A Tembo Postgres Stack configured to support vector data types, storage, and operations.
 organization: tembo
 images:
-  14: "standard-cnpg:pg14-f1721c2"
+  14: "standard-cnpg:14-a0a5ab5"
   15: "standard-cnpg:15.3.0-1-3d9a853"
-  16: "standard-cnpg:pg16-f1721c2"
+  16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:7dc6329

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -1,5 +1,6 @@
 name: VectorDB
 description: A Tembo Postgres Stack configured to support vector data types, storage, and operations.
+repository: "quay.io/tembo"
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -1,7 +1,10 @@
 name: VectorDB
 description: A Tembo Postgres Stack configured to support vector data types, storage, and operations.
-repository: "quay.io/tembo"
-image: "standard-cnpg:15.3.0-1-3d9a853"
+organization: tembo
+images:
+  14: "standard-cnpg:pg14-f1721c2"
+  15: "standard-cnpg:15.3.0-1-3d9a853"
+  16: "standard-cnpg:pg16-f1721c2"
 stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:7dc6329

--- a/tembo-operator/src/stacks/templates/vectordb.yaml
+++ b/tembo-operator/src/stacks/templates/vectordb.yaml
@@ -3,7 +3,7 @@ description: A Tembo Postgres Stack configured to support vector data types, sto
 organization: tembo
 images:
   14: "standard-cnpg:14-a0a5ab5"
-  15: "standard-cnpg:15.3.0-1-3d9a853"
+  15: "standard-cnpg:15-a0a5ab5"
   16: "standard-cnpg:16-a0a5ab5"
 stack_version: 0.1.0
 appServices:

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -75,7 +75,7 @@ pub struct Stack {
     #[serde(default = "default_stack_repository")]
     pub repository: String,
     /// The Docker images to use for each supported Postgres versions
-    /// 
+    ///
     /// Default:
     ///   14: "standard-cnpg:pg14-f1721c2"
     ///   15: "standard-cnpg:15.3.0-1-3d9a853"

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -77,9 +77,9 @@ pub struct Stack {
     /// The Docker images to use for each supported Postgres versions
     ///
     /// Default:
-    ///   14: "standard-cnpg:pg14-f1721c2"
-    ///   15: "standard-cnpg:15.3.0-1-3d9a853"
-    ///   16: "standard-cnpg:pg16-f1721c2"
+    ///     14: "standard-cnpg:14-a0a5ab5"
+    ///     15: "standard-cnpg:15-a0a5ab5"
+    ///     16: "standard-cnpg:16-a0a5ab5"
     #[serde(default = "default_images")]
     pub images: ImagePerPgVersion,
     pub stack_version: Option<String>,

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -1,7 +1,7 @@
 use crate::{
     apis::postgres_parameters::PgConfig,
     app_service::types::AppService,
-    defaults::{default_image, default_repository},
+    defaults::{default_images, default_repository},
     extensions::types::{Extension, TrunkInstall},
     postgres_exporter::QueryConfig,
     stacks::config_engines::{
@@ -69,10 +69,19 @@ pub struct Stack {
     pub name: String,
     pub compute_templates: Option<Vec<ComputeTemplate>>,
     pub description: Option<String>,
+    /// Organization hosting the Docker images used in this stack
+    /// Default: "tembo"
+    pub organization: String,
     #[serde(default = "default_stack_repository")]
-    pub repository: Option<String>,
-    #[serde(default = "default_stack_image")]
-    pub image: Option<String>,
+    pub repository: String,
+    /// The Docker images to use for each supported Postgres versions
+    /// 
+    /// Default:
+    ///   14: "standard-cnpg:pg14-f1721c2"
+    ///   15: "standard-cnpg:15.3.0-1-3d9a853"
+    ///   16: "standard-cnpg:pg16-f1721c2"
+    #[serde(default = "default_images")]
+    pub images: ImagePerPgVersion,
     pub stack_version: Option<String>,
     pub trunk_installs: Option<Vec<TrunkInstall>>,
     pub extensions: Option<Vec<Extension>>,
@@ -100,12 +109,8 @@ impl Stack {
     }
 }
 
-fn default_stack_repository() -> Option<String> {
-    Some(default_repository())
-}
-
-fn default_stack_image() -> Option<String> {
-    Some(default_image())
+fn default_stack_repository() -> String {
+    default_repository()
 }
 
 fn default_config_engine() -> Option<ConfigEngine> {
@@ -150,10 +155,25 @@ pub enum InstanceClass {
     ComputeOptimized,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
+pub struct ImagePerPgVersion {
+    #[serde(rename = "14")]
+    pub pg14: String,
+    #[serde(rename = "15")]
+    pub pg15: String,
+    #[serde(rename = "16")]
+    pub pg16: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stacks::{get_stack, types::Infrastructure, StackType};
+    use crate::stacks::{get_stack, types::Infrastructure, StackType, STANDARD};
+
+    #[test]
+    fn ababa() {
+        dbg!(&*STANDARD);
+    }
 
     #[test]
     fn test_stacks_definitions() {


### PR DESCRIPTION
New fields:

```yml
# Within the Docker image registry used (quay.io or ECR), this is the
# organization/username the images below are contained in
organization: tembo
# Image names to use for each Pg version
# Note: images for Pg15 were kept as is as to preserve full backwards compatibility
images:
  14: "standard-cnpg:pg14-f1721c2"
  15: "standard-cnpg:15.3.0-1-3d9a853"
  16: "standard-cnpg:pg16-f1721c2"
  ```

Control Plane will use the above information to set the instance's image according to the `pg_version` attribute in the `POST /instances` endpoint (defaults to Pg15)