### PR TITLE
moves merge_options to tembo-stacks from control-plane so it can be shared

### DIFF
--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/apps/app.rs
+++ b/tembo-stacks/src/apps/app.rs
@@ -165,6 +165,22 @@ pub fn merge_app_reqs(
     })
 }
 
+// used for merging Vec of requested with Vec in Stack spec
+#[instrument(skip(opt1, opt2))]
+pub fn merge_options<T>(opt1: Option<Vec<T>>, opt2: Option<Vec<T>>) -> Option<Vec<T>>
+where
+    T: Clone,
+{
+    match (opt1, opt2) {
+        (Some(mut vec1), Some(vec2)) => {
+            vec1.extend(vec2);
+            Some(vec1)
+        }
+        (Some(vec), None) | (None, Some(vec)) => Some(vec),
+        (None, None) => None,
+    }
+}
+
 #[instrument]
 pub fn merge_location_into_extensions(
     extension_name: &str,


### PR DESCRIPTION
Follow up PR to change `control-plane` coming up next once the new crate is published