### PR TITLE
Increase buffer size on exec function

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.34.1"
+version = "0.34.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/exec.rs
+++ b/tembo-operator/src/exec.rs
@@ -40,9 +40,9 @@ impl ExecCommand {
             stdin: true,
             stdout: true,
             stderr: true,
-            max_stdin_buf_size: Some(1024),
-            max_stdout_buf_size: Some(1024),
-            max_stderr_buf_size: Some(1024),
+            max_stdin_buf_size: Some(10240),
+            max_stdout_buf_size: Some(10240),
+            max_stderr_buf_size: Some(10240),
         };
 
         let mut attached_process = self

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1110,11 +1110,15 @@ mod test {
                     },
                     {
                         "name": "pgmq",
-                        "version": "0.10.0",
+                        "version": "1.1.1",
                     },
                     {
                         "name": "pg_stat_statements",
                         "version": "1.10.0",
+                    },
+                    {
+                        "name": "postgis",
+                        "version": "3.4.0",
                     },
                 ],
                 "extensions": [
@@ -1133,7 +1137,7 @@ mod test {
                         "locations": [
                         {
                           "enabled": true,
-                          "version": "0.10.0",
+                          "version": "1.1.1",
                           "database": "postgres",
                           "schema": "public"
                         }]
@@ -1144,6 +1148,16 @@ mod test {
                         {
                           "enabled": true,
                           "version": "1.10.0",
+                          "database": "postgres",
+                          "schema": "public"
+                        }]
+                    },
+                    {
+                        "name": "postgis",
+                        "locations": [
+                        {
+                          "enabled": true,
+                          "version": "3.4.0",
                           "database": "postgres",
                           "schema": "public"
                         }]
@@ -1191,6 +1205,18 @@ mod test {
 
         println!("{}", result.stdout.clone().unwrap());
         assert!(result.stdout.clone().unwrap().contains("pgmq"));
+
+        let result = wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "select extname from pg_catalog.pg_extension;".to_string(),
+            "postgis".to_string(),
+            false,
+        )
+        .await;
+
+        println!("{}", result.stdout.clone().unwrap());
+        assert!(result.stdout.clone().unwrap().contains("postgis"));
 
         println!("Restarting CNPG pod");
         // Restart the CNPG instance

--- a/tembo-operator/yaml/sample-coredb.yaml
+++ b/tembo-operator/yaml/sample-coredb.yaml
@@ -16,7 +16,7 @@ spec:
         - enabled: true
           database: postgres
           schema: public
-          version: "1.5.2"
+          version: "1.6.2"
   runtime_config:
     - name: shared_preload_libraries
       value: 'pg_cron,pg_stat_statements'

--- a/tembo-operator/yaml/sample-document.yaml
+++ b/tembo-operator/yaml/sample-document.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-document
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   stop: false
   stack:
     name: Document

--- a/tembo-operator/yaml/sample-dw.yaml
+++ b/tembo-operator/yaml/sample-dw.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: tembo-dw
 spec:
-  image: quay.io/tembo/dw-cnpg:15.3.0-1-0baf38f
+  image: quay.io/tembo/dw-cnpg:15-a0a5ab5
   stack:
     name: DataWarehouse
   runtime_config:

--- a/tembo-operator/yaml/sample-machine-learning-backup.yaml
+++ b/tembo-operator/yaml/sample-machine-learning-backup.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-machine-learning-backup
 spec:
-  image: "quay.io/tembo/ml-cnpg:15.3.0-1-a3e532d"
+  image: "quay.io/tembo/ml-cnpg:15-a0a5ab5"
   backup:
     destinationPath: s3://tembo-backup/sample-machine-learning-backup
     encryption: ""
@@ -38,7 +38,7 @@ spec:
     - name: pg_cron
       version: 1.5.2
     - name: pgmq
-      version: 0.28.0
+      version: 1.1.1
     - name: vectorize
       version: 0.0.2
     - name: pg_later
@@ -67,7 +67,7 @@ spec:
       locations:
         - database: postgres
           enabled: true
-          version: 0.28.0
+          version: 1.1.1
     - name: vectorize
       description: simple vector search
       locations:

--- a/tembo-operator/yaml/sample-machine-learning-restore.yaml
+++ b/tembo-operator/yaml/sample-machine-learning-restore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-machine-learning-restore
   namespace: restore
 spec:
-  image: "quay.io/tembo/ml-cnpg:15.3.0-1-a3e532d"
+  image: "quay.io/tembo/ml-cnpg:15-a0a5ab5"
   backup:
     destinationPath: s3://tembo-backup/sample-machine-learning-restore
     encryption: ""
@@ -49,7 +49,7 @@ spec:
     - name: pg_cron
       version: 1.5.2
     - name: pgmq
-      version: 0.28.0
+      version: 1.1.1
     - name: vectorize
       version: 0.0.2
     - name: pg_later
@@ -78,7 +78,7 @@ spec:
       locations:
         - database: postgres
           enabled: true
-          version: 0.28.0
+          version: 1.1.1
     - name: vectorize
       description: simple vector search
       locations:

--- a/tembo-operator/yaml/sample-machine-learning.yaml
+++ b/tembo-operator/yaml/sample-machine-learning.yaml
@@ -3,28 +3,28 @@ kind: CoreDB
 metadata:
   name: sample-machine-learning
 spec:
-  image: "quay.io/tembo/ml-cnpg:15.3.0-1-a3e532d"
+  image: "quay.io/tembo/ml-cnpg:15-a0a5ab5"
   trunk_installs:
     - name: pgvector
-      version: 0.5.1
+      version: 0.6.0
     - name: postgresml
       version: 2.7.1
     - name: pg_embedding
-      version: 0.1.0
-    - name: pg_cron
-      version: 1.5.2
-    - name: pgmq
-      version: 0.31.0
-    - name: vectorize
       version: 0.2.0
+    - name: pg_cron
+      version: 1.6.2
+    - name: pgmq
+      version: 1.1.1
+    - name: vectorize
+      version: 0.9.0
     - name: pg_later
-      version: 0.0.11
+      version: 0.1.0
   extensions:
     - name: vector
       locations:
         - database: postgres
           enabled: true
-          version: 0.5.0
+          version: 0.6.0
     - name: pgml
       locations:
         - database: postgres
@@ -34,19 +34,19 @@ spec:
       locations:
         - database: postgres
           enabled: true
-          version: 1.5.2
+          version: 1.6.2
     - name: pgmq
       locations:
         - database: postgres
           enabled: true
-          version: 0.31.0
+          version: 1.1.1
     - name: vectorize
       locations:
         - database: postgres
           enabled: true
-          version: 0.2.0
+          version: 0.9.0
     - name: pg_later
       locations:
         - database: postgres
           enabled: true
-          version: 0.0.11
+          version: 0.1.0

--- a/tembo-operator/yaml/sample-olap.yaml
+++ b/tembo-operator/yaml/sample-olap.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-olap
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   stop: false
   stack:
     name: OLAP

--- a/tembo-operator/yaml/sample-oltp.yaml
+++ b/tembo-operator/yaml/sample-oltp.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-oltp
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   stop: false
   stack:
     name: OLTP

--- a/tembo-operator/yaml/sample-standard-backup.yaml
+++ b/tembo-operator/yaml/sample-standard-backup.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-standard-backup
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   backup:
     destinationPath: s3://tembo-backup/sample-standard-backup
     encryption: ""

--- a/tembo-operator/yaml/sample-standard-restore.yaml
+++ b/tembo-operator/yaml/sample-standard-restore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sample-standard-restore
   namespace: restore
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   backup:
     destinationPath: s3://tembo-backup/sample-standard-restore
     retentionPolicy: "30"

--- a/tembo-operator/yaml/sample-standard.yaml
+++ b/tembo-operator/yaml/sample-standard.yaml
@@ -3,7 +3,7 @@ kind: CoreDB
 metadata:
   name: sample-standard
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   stop: false
   stack:
     name: Standard

--- a/tembo-operator/yaml/sample-vectordb.yaml
+++ b/tembo-operator/yaml/sample-vectordb.yaml
@@ -3,10 +3,10 @@ kind: CoreDB
 metadata:
   name: sample-vectordb
 spec:
-  image: "quay.io/tembo/standard-cnpg:15.3.0-1-45c2054"
+  image: "quay.io/tembo/standard-cnpg:15-a0a5ab5"
   trunk_installs:
     - name: pgmq
-      version: 0.32.3
+      version: 1.1.1
     - name: vectorize
       version: 0.4.0
     - name: pgvector
@@ -28,7 +28,7 @@ spec:
       locations:
       - database: postgres
         enabled: true
-        version: 0.32.3
+        version: 1.1.1
     - name: vectorize
       locations:
       - database: postgres


### PR DESCRIPTION
* Increase the byte size for `stdin`, `stderr` and `stdout` for the `execute` function
* Update the sample YAML files to utilize the newer base container images
* Update the sample YAML files to use the latest version of pgmq
* Write test to install and check for the installation of the `postgis` extention