### PR TITLE
Fix pganalyze app service name

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "controller",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/apps/pganalyze.yaml
+++ b/tembo-stacks/src/apps/pganalyze.yaml
@@ -1,7 +1,7 @@
 name: !pganalyze
 appServices:
   - image: quay.io/pganalyze/collector:v0.53.0
-    name: pganalyze-collector
+    name: pganalyze
     env:
       - name: DB_URL
         valueFromPlatform: ReadWriteConnection


### PR DESCRIPTION
The pganalyze app service was named `pganalyze-collector`. Because of this, it was considered a custom app service. Updating name to `pganalyze` so it will be recognized as `AppType::PgAnalyze`.

Related failure:
- https://github.com/tembo-io/control-plane/actions/runs/7894114700/job/21544114520?pr=512#step:7:2176