### PR TITLE
Bump tembo stacks version.

### DIFF
--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Missing piece to [https://github.com/tembo-io/tembo/pull/565](https://github.com/tembo-io/tembo/pull/565), which is an essential step before updating control plane.