### PR TITLE
Bump controller dependency in stacks crate

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.35.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12c883ade39dff600cc93650c90dfbf26b80aebbe00bde70b4dce3df3f1c18c"
+checksum = "1c6bdbeb72f960ddd2674a290fb911f476f14ca98ff6472257dacf763f3d4e48"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.3.4"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "controller",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,6 +16,6 @@ schemars = {version = "0.8.12", features = ["chrono"]}
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false } # This version has to be in line with the same version we use in the controller
 serde = "1.0.152"
 serde_yaml = "0.9.21"
-tembo-controller = { package = "controller", version = "0.35.4" }
+tembo-controller = { package = "controller", version = "0.36.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }


### PR DESCRIPTION
@EvanHStanton and I found that when bumping the control-plane's `controller` crate to `0.36.0`, the `Cargo.lock` file pulled in two versions of the `controller` crate:
Related PR:
- https://github.com/tembo-io/control-plane/pull/521

The `tembo-stacks` crate was showing `controller 0.35.5` as a dependency. This should resolve the issue.

### Multiple versions in `Cargo.lock`
```
[[package]]
name = "controller"
version = "0.35.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "ccf3edc4f1f4872ef3a31f709753c70809cfbab2b0400d5f2754db769d436fd4"
dependencies = [
 "actix-web",
 "anyhow",
 "base64 0.21.7",
 "chrono",
 "futures",
 "itertools 0.11.0",
 "k8s-openapi",
 "kube",
 "lazy_static",
 "opentelemetry 0.19.0",
 "passwords",
 "prometheus",
 "rand 0.8.5",
 "regex",
 "reqwest",
 "schemars",
 "semver",
 "serde",
 "serde_json",
 "serde_yaml",
 "thiserror",
 "tokio",
 "tracing",
 "tracing-opentelemetry 0.19.0",
 "tracing-subscriber",
 "utoipa",
]

[[package]]
name = "controller"
version = "0.36.0"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "1c6bdbeb72f960ddd2674a290fb911f476f14ca98ff6472257dacf763f3d4e48"
dependencies = [
 "actix-web",
 "anyhow",
 "base64 0.21.7",
 "chrono",
 "futures",
 "itertools 0.11.0",
 "k8s-openapi",
 "kube",
 "lazy_static",
 "opentelemetry 0.19.0",
 "passwords",
 "prometheus",
 "rand 0.8.5",
 "regex",
 "reqwest",
 "schemars",
 "semver",
 "serde",
 "serde_json",
 "serde_yaml",
 "thiserror",
 "tokio",
 "tracing",
 "tracing-opentelemetry 0.19.0",
 "tracing-subscriber",
 "utoipa",
]
```

### Wrong controller version in `tembo-stacks` dependencies in `Cargo.lock` file
```
[[package]]
name = "tembo-stacks"
version = "0.3.5"
source = "registry+https://github.com/rust-lang/crates.io-index"
checksum = "9b323976d5947019e37e76fb0110b211cffc4763b7fa86acd07c644428db1aa3"
dependencies = [
 "anyhow",
 "controller 0.35.5",
 "futures",
 "k8s-openapi",
 "lazy_static",
 "schemars",
 "serde",
 "serde_yaml",
 "tracing",
 "utoipa",
]
```