### PR TITLE
Add check to make sure VolumeSnapshotContent is created and ready

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.36.3"
+version = "0.36.4"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.36.3"
+version = "0.36.4"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/snapshots/volumesnapshots.rs
+++ b/tembo-operator/src/snapshots/volumesnapshots.rs
@@ -3,10 +3,12 @@ use crate::{
     snapshots::{
         volumesnapshotcontents_crd::{
             VolumeSnapshotContent, VolumeSnapshotContentDeletionPolicy,
-            VolumeSnapshotContentSource, VolumeSnapshotContentSpec,
+            VolumeSnapshotContentSource, VolumeSnapshotContentSpec, VolumeSnapshotContentStatus,
             VolumeSnapshotContentVolumeSnapshotRef,
         },
-        volumesnapshots_crd::{VolumeSnapshot, VolumeSnapshotSource, VolumeSnapshotSpec},
+        volumesnapshots_crd::{
+            VolumeSnapshot, VolumeSnapshotSource, VolumeSnapshotSpec, VolumeSnapshotStatus,
+        },
     },
     Context,
 };
@@ -304,7 +306,7 @@ fn generate_volume_snapshot_content(
             },
             ..VolumeSnapshotContentSpec::default()
         },
-        status: None,
+        status: Some(VolumeSnapshotContentStatus::default()),
     };
 
     Ok(vsc)
@@ -340,7 +342,7 @@ fn generate_volume_snapshot(
             },
             ..VolumeSnapshotSpec::default()
         },
-        status: None,
+        status: Some(VolumeSnapshotStatus::default()),
     };
     Ok(vs)
 }


### PR DESCRIPTION
* Adding check to ensure the `VolumeSnapshotContent` is ready and applied before applying the `VolumeSnapshot`

This hopefully fixes a possible race condition where  the snapshot cannot be bound to the snapshotcontents.

* minor fixes and cleanup