### PR TITLE
uses the extension version installed if new version in uploaded to trunk

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "actix-cors",
  "actix-service",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.18.2"
+version = "0.19.0"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -634,7 +634,7 @@ fn get_extensions(
                             "Current version of extension {} installed is different than version on trunk",
                             name);
                         let ext_locations = extension_mismatch.unwrap().locations.clone();
-                        if ext_locations.len() > 0 {
+                        if !ext_locations.is_empty() {
                             if let Some(existing_version) = ext_locations[0].clone().version {
                                 version = existing_version
                             } else {

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -612,7 +612,7 @@ fn get_extensions(
 
     if let Some(extensions) = maybe_extensions {
         for (name, extension) in extensions.into_iter() {
-            let version = Runtime::new().unwrap().block_on(get_extension_version(
+            let mut version = Runtime::new().unwrap().block_on(get_extension_version(
                 name.clone(),
                 extension.clone().version,
             ))?;
@@ -630,7 +630,16 @@ fn get_extensions(
                             name
                         )));
                     } else {
-                        continue;
+                        let ext_locations = extension_mismatch.unwrap().locations.clone();
+                        if ext_locations.len() > 0 {
+                            if let Some(existing_version) = ext_locations[0].clone().version {
+                                version = existing_version
+                            }
+                        } else {
+                            return Err(Error::msg(format!(
+                            "Current version of extension {} installed is different than version on trunk",
+                            name)));
+                        }
                     }
                 }
             }

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -630,15 +630,18 @@ fn get_extensions(
                             name
                         )));
                     } else {
+                        let version_error = format!(
+                            "Current version of extension {} installed is different than version on trunk",
+                            name);
                         let ext_locations = extension_mismatch.unwrap().locations.clone();
                         if ext_locations.len() > 0 {
                             if let Some(existing_version) = ext_locations[0].clone().version {
                                 version = existing_version
+                            } else {
+                                return Err(Error::msg(version_error));
                             }
                         } else {
-                            return Err(Error::msg(format!(
-                            "Current version of extension {} installed is different than version on trunk",
-                            name)));
+                            return Err(Error::msg(version_error));
                         }
                     }
                 }


### PR DESCRIPTION
Extensions can be `enabled` later so instead of skipping the extension using the version that's already installed in case it's not specified in `tembo.toml`