### PR TITLE
adds stack as alias for stack_type, deny_unknown_fields

### DIFF
--- a/tembo-cli/src/cli/tembo_config.rs
+++ b/tembo-cli/src/cli/tembo_config.rs
@@ -13,6 +13,7 @@ pub struct TemboConfig {
 
 // Config struct holds to data from the `[config]` section.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct InstanceSettings {
     pub environment: String,
     pub instance_name: String,
@@ -25,6 +26,7 @@ pub struct InstanceSettings {
     #[serde(default = "default_replicas")]
     pub replicas: i32,
     #[serde(default = "default_stack_type")]
+    #[serde(alias = "stack")]
     pub stack_type: String,
     pub postgres_configurations: Option<HashMap<String, Value>>,
     #[serde(default = "default_pg_version")]

--- a/tembo-cli/src/cmd/top.rs
+++ b/tembo-cli/src/cmd/top.rs
@@ -34,7 +34,7 @@ pub struct MetricsResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsData {
-    pub resultType: String,
+    pub result_type: String,
     pub result: Vec<MetricResult>,
 }
 

--- a/tembo-cli/src/cmd/top.rs
+++ b/tembo-cli/src/cmd/top.rs
@@ -34,7 +34,7 @@ pub struct MetricsResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct MetricsData {
-    pub result_type: String,
+    pub resultType: String,
     pub result: Vec<MetricResult>,
 }
 


### PR DESCRIPTION
* stack as alias for stack_type
* shows below error for unknown field: 
![Screenshot 2024-03-03 at 8 26 36 PM](https://github.com/tembo-io/tembo/assets/4085531/e9110a8b-50a3-4cd1-95d0-d7e5d0110ef6)
