### PR TITLE
Patch VolumeSnapshotContent with the UID of the VolumeSnapshot

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.37.9"
+version = "0.37.10"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.37.9"
+version = "0.37.10"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/snapshots/volumesnapshots.rs
+++ b/tembo-operator/src/snapshots/volumesnapshots.rs
@@ -310,29 +310,11 @@ fn generate_volume_snapshot_content(
             Action::requeue(tokio::time::Duration::from_secs(300))
         })?;
     let snapshot = format!("{}-restore-vs", name);
-    let restore_from_name = cdb
-        .spec
-        .restore
-        .as_ref()
-        .map(|r| r.server_name.clone())
-        .ok_or_else(|| {
-            error!(
-                "CoreDB restore server_name is empty for instance {}",
-                cdb.name_any()
-            );
-            Action::requeue(tokio::time::Duration::from_secs(300))
-        })?;
-
-    let mut vsc_labels = BTreeMap::new();
-    vsc_labels.insert("cnpg.io/cluster".to_string(), name.clone());
-    vsc_labels.insert("tembo.io/restore".to_string(), "true".to_string());
-    vsc_labels.insert("tembo.io/restore-from".to_string(), restore_from_name);
 
     let vsc = VolumeSnapshotContent {
         metadata: ObjectMeta {
             name: Some(format!("{}-restore-vsc", name)),
             namespace: Some(namespace.clone()),
-            labels: Some(vsc_labels),
             ..ObjectMeta::default()
         },
         spec: VolumeSnapshotContentSpec {
@@ -382,29 +364,11 @@ fn generate_volume_snapshot(
             error!("VolumeSnapshotClass name is empty for instance {}", name);
             Action::requeue(tokio::time::Duration::from_secs(300))
         })?;
-    let restore_from_name = cdb
-        .spec
-        .restore
-        .as_ref()
-        .map(|r| r.server_name.clone())
-        .ok_or_else(|| {
-            error!(
-                "CoreDB restore server_name is empty for instance {}",
-                cdb.name_any()
-            );
-            Action::requeue(tokio::time::Duration::from_secs(300))
-        })?;
-
-    let mut vsc_labels = BTreeMap::new();
-    vsc_labels.insert("cnpg.io/cluster".to_string(), name.clone());
-    vsc_labels.insert("tembo.io/restore".to_string(), "true".to_string());
-    vsc_labels.insert("tembo.io/restore-from".to_string(), restore_from_name);
 
     let vs = VolumeSnapshot {
         metadata: ObjectMeta {
             name: Some(format!("{}-restore-vs", name)),
             namespace: Some(namespace),
-            labels: Some(vsc_labels),
             ..ObjectMeta::default()
         },
         spec: VolumeSnapshotSpec {

--- a/tembo-operator/src/snapshots/volumesnapshots.rs
+++ b/tembo-operator/src/snapshots/volumesnapshots.rs
@@ -26,23 +26,103 @@ pub async fn reconcile_volume_snapshot_restore(
     ctx: Arc<Context>,
 ) -> Result<VolumeSnapshot, Action> {
     let client = ctx.client.clone();
+
     // Lookup the VolumeSnapshot of the original instance
-    let ogvs = lookup_volume_snapshot(cdb, &client).await?;
+    let cdb_name = cdb
+        .spec
+        .restore
+        .as_ref()
+        .map(|r| r.server_name.clone())
+        .ok_or_else(|| {
+            error!(
+                "CoreDB restore server_name is empty for instance {}",
+                cdb.name_any()
+            );
+            Action::requeue(tokio::time::Duration::from_secs(300))
+        })?;
+    let cnpg_ls = format!("cnpg.io/cluster={}", cdb_name);
+    let ogvs = lookup_volume_snapshot(&client, cdb_name, cnpg_ls).await?;
+
+    // Lookup the VolumeSnapshotContent of the original instance
     let ogvsc = lookup_volume_snapshot_content(cdb, &client, ogvs).await?;
 
+    // Generate the VolumeSnapshotContent and VolumeSnapshot for the restore
     let vsc = generate_volume_snapshot_content(cdb, &ogvsc)?;
     let vs = generate_volume_snapshot(cdb, &vsc)?;
 
     // Apply the VolumeSnapshotContent and VolumeSnapshot
     apply_volume_snapshot_content(cdb, &client, &vsc).await?;
-
-    // Apply the VolumeSnapshot
     apply_volume_snapshot(cdb, &client, &vs).await?;
+
+    // Patch the VolumeSnapshotContent with the UID of the VolumeSnapshot
+    let new_vs_name = vs.metadata.name.as_ref().ok_or_else(|| {
+        error!(
+            "VolumeSnapshot name is empty for instance: {}.",
+            cdb.name_any()
+        );
+        Action::requeue(tokio::time::Duration::from_secs(300))
+    })?;
+    let ls = format!("metadata.name={}", new_vs_name);
+    let new_vs = lookup_volume_snapshot(&client, new_vs_name.to_string(), ls).await?;
+    patch_volume_snapshot_content(cdb, &client, &vsc, &new_vs).await?;
 
     // We need to wait for the snapshot to become ready before we can proceed
     is_snapshot_ready(cdb, &client, &vs).await?;
 
     Ok(vs)
+}
+
+async fn patch_volume_snapshot_content(
+    cdb: &CoreDB,
+    client: &Client,
+    vsc: &VolumeSnapshotContent,
+    vs: &VolumeSnapshot,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+    let vsc_name = vsc.metadata.name.as_ref().ok_or_else(|| {
+        error!(
+            "VolumeSnapshotContent name is empty for instance: {}.",
+            cdb.name_any()
+        );
+        Action::requeue(tokio::time::Duration::from_secs(300))
+    })?;
+
+    // Apply VolumeSnapshotContent (All Namespaces)
+    let vsc_api: Api<VolumeSnapshotContent> = Api::all(client.clone());
+    debug!("Patching VolumeSnapshotContent for instance: {}", name);
+    let ps = PatchParams::apply("cntrlr").force();
+
+    // Check if the VolumeSnapshot (vs) has a UID, requeue if it doesn't
+    let vs_uid = vs.metadata.uid.as_ref().ok_or_else(|| {
+        error!(
+            "VolumeSnapshot UID is empty for instance: {}.",
+            cdb.name_any()
+        );
+        Action::requeue(tokio::time::Duration::from_secs(10))
+    })?;
+
+    let mut new_vsc = vsc.clone();
+    new_vsc.spec.volume_snapshot_ref = VolumeSnapshotContentVolumeSnapshotRef {
+        api_version: Some("snapshot.storage.k8s.io/v1".to_string()),
+        kind: Some("VolumeSnapshot".to_string()),
+        name: vs.metadata.name.clone(),
+        namespace: vs.metadata.namespace.clone(),
+        uid: Some(vs_uid.to_string()),
+        ..VolumeSnapshotContentVolumeSnapshotRef::default()
+    };
+
+    match vsc_api.patch(vsc_name, &ps, &Patch::Apply(&new_vsc)).await {
+        Ok(_) => debug!("VolumeSnapshotContent patched successfully for {}.", name),
+        Err(e) => {
+            error!(
+                "Failed to patch VolumeSnapshotContent for instance {}: {}",
+                name, e
+            );
+            return Err(Action::requeue(tokio::time::Duration::from_secs(300)));
+        }
+    }
+
+    Ok(())
 }
 
 async fn is_snapshot_ready(
@@ -300,35 +380,21 @@ fn generate_volume_snapshot(
 
 // lookup_volume_snapshot function looks up the VolumeSnapshot object from the
 // original instance you are restoring from
-async fn lookup_volume_snapshot(cdb: &CoreDB, client: &Client) -> Result<VolumeSnapshot, Action> {
-    // name will be the name of the original instance
-    let name = cdb
-        .spec
-        .restore
-        .as_ref()
-        .map(|r| r.server_name.clone())
-        .ok_or_else(|| {
-            error!(
-                "CoreDB restore server_name is empty for instance {}",
-                cdb.name_any()
-            );
-            Action::requeue(tokio::time::Duration::from_secs(300))
-        })?;
-
-    // todo: This is a temporary fix to get the VolumeSnapshot from the same namespace as the
-    // instance you are attempting to restore from.  We need to figure out a better way of
-    // doing this in case someone wants to name a namespace differently than the instance name.
+async fn lookup_volume_snapshot(
+    client: &Client,
+    name: String,
+    label_selector: String,
+) -> Result<VolumeSnapshot, Action> {
     let volume_snapshot_api: Api<VolumeSnapshot> = Api::namespaced(client.clone(), &name);
 
-    let label_selector = format!("cnpg.io/cluster={}", name);
     let lp = ListParams::default().labels(&label_selector);
-    let backup_result = volume_snapshot_api.list(&lp).await.map_err(|e| {
+    let result = volume_snapshot_api.list(&lp).await.map_err(|e| {
         error!("Error listing VolumeSnapshots for instance {}: {}", name, e);
         Action::requeue(tokio::time::Duration::from_secs(300))
     })?;
 
     // Filter snapshots that are ready to use and sort them by creation timestamp in descending order
-    let mut snapshots: Vec<VolumeSnapshot> = backup_result
+    let mut snapshots: Vec<VolumeSnapshot> = result
         .items
         .into_iter()
         .filter(|vs| {


### PR DESCRIPTION
Due to this error in the `csi-provisioner` we need to also set the UID of the `VolumeSnapshot`

```
W0304 22:03:14.918800       1 controller.go:1108] snapshotcontent org-tembo-test-inst-snapshot-rst-mar4-restore-vsc for snapshot org-tembo-test-inst-snapshot-rst-mar4/org-tembo-test-inst-snapshot-rst-mar4-restore-vs is bound to a different snapshot
```

The relevant code that would check for the UID is [here](https://github.com/kubernetes-csi/external-provisioner/blob/ef83836bc21e5a737ded6d0f37f8a5f6a97d8973/pkg/controller/controller.go#L1162-L1165) from the external-provisioner.