### PR TITLE
force scheduledbackup for snapshots to truncate names over 43 characters

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.37.11"
+version = "0.37.12"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.37.11"
+version = "0.37.12"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
Due to Kubernetes name length constraints we need to truncate the name of the `ScheduledBackup` for the `VolumeSnapshot`.  This will ensure that the snapshot can be scheduled on the cluster.

issue: [TEM-3220](https://linear.app/tembo/issue/TEM-3220/invalid-name-length-on-snapshot-recovery-job)