### PR TITLE
add better handling of snapshot restores, better debug logging

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.37.13"
+version = "0.38.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -687,6 +687,11 @@ async fn init_cloud_perms(
         // use volume_snapshot_enabled feature flag to only enable for specific org_id's
         let volume_snapshot_enabled = is_volume_snapshot_enabled(read_msg, &restore_spec);
 
+        info!(
+            "Volume snapshot restore is {} for instance_id {} in org_id: {}",
+            volume_snapshot_enabled, read_msg.message.inst_id, read_msg.message.org_id
+        );
+
         // Ensure a restore spec exists, otherwise return an error
         let restore =
             coredb_spec
@@ -732,8 +737,8 @@ fn is_volume_snapshot_enabled(msg: &Message<CRUDevent>, cdb_spec: &CoreDBSpec) -
 
     if orgs.contains(&msg.message.org_id.as_str()) {
         info!(
-            "Volume snapshot restore enabled for org_id: {}",
-            msg.message.org_id
+            "Volume snapshot restore enabled for instance_id {} in org_id: {}",
+            msg.message.inst_id, msg.message.org_id
         );
         cdb_spec
             .backup
@@ -742,8 +747,8 @@ fn is_volume_snapshot_enabled(msg: &Message<CRUDevent>, cdb_spec: &CoreDBSpec) -
             .map_or(false, |vs| vs.enabled)
     } else {
         info!(
-            "Volume snapshot restore disabled for org_id: {}",
-            msg.message.org_id
+            "Volume snapshot restore disabled for instance_id {} in org_id: {}",
+            msg.message.inst_id, msg.message.org_id
         );
         false
     }

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.38.0"
+version = "0.38.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1022,7 +1022,7 @@ pub async fn reconcile_cnpg(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Actio
     // the VolumeSnapshotContent and VolumeSnapshot so that the Cluster will have
     // something to restore from.
     if let Some(restore) = &cdb.spec.restore {
-        if restore.volume_snapshot.is_some() {
+        if restore.volume_snapshot == Some(true) {
             debug!("Reconciling VolumeSnapshotContent and VolumeSnapshot for restore");
             reconcile_volume_snapshot_restore(cdb, ctx.clone()).await?;
         }


### PR DESCRIPTION
This PR is an attempt to fix a few issues surrounding restoring using `VolumeSnapshots`

* Fix issue where we can't searching using metadata fields via the k8s API
```
2024-03-07T17:05:45.437283Z ERROR reconciling object:reconcile:reconcile:reconcile_cnpg: controller::snapshots::volumesnapshots:441: No ready VolumeSnapshots found for org-coredb-inst-test-isnt-403 object.ref=CoreDB.v1alpha1.coredb.io/org-coredb-inst-test-isnt-403-240304.org-coredb-inst-test-isnt-403-240304 object.reason=reconciler requested retry trace_id=00000000000000000000000000000000 instance_name=org-coredb-inst-test-isnt-403-240304
```

* Add better logging in conductor to help troubleshoot where sometimes `spec.restore.volumeSnapshot` is `null` instead of a `boolean`.

issue: [TEM-3281](https://linear.app/tembo/issue/TEM-3281/error-in-operator-when-restoring-via-object-store)