### PR TITLE
check if restore.volumeSnapshots is true

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.38.1"
+version = "0.38.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.38.1"
+version = "0.38.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -514,7 +514,7 @@ fn cnpg_cluster_bootstrap_recovery_volume_snapshots(
     cdb: &CoreDB,
 ) -> Option<ClusterBootstrapRecoveryVolumeSnapshots> {
     if let Some(restore) = &cdb.spec.restore {
-        if restore.volume_snapshot.is_some() {
+        if restore.volume_snapshot == Some(true) {
             return Some(ClusterBootstrapRecoveryVolumeSnapshots {
                 storage: ClusterBootstrapRecoveryVolumeSnapshotsStorage {
                     // todo: Work on getting this from the VolumeSnapshot we created


### PR DESCRIPTION
Fix issue where we need to explicitly check for `true` when restoring from a `VolumeSnapshot`

fixes: [TEM-3281](https://linear.app/tembo/issue/TEM-3281/error-in-operator-when-restoring-via-object-store)