### PR TITLE
add config option to enable volume snapshots in the operator

### DIFF
--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: 'Helm chart to deploy the tembo-operator'
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.4.1
+version: 0.5.0
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo

--- a/charts/tembo-operator/templates/deployment-operator.yaml
+++ b/charts/tembo-operator/templates/deployment-operator.yaml
@@ -32,13 +32,19 @@ spec:
         - image: {{ (index .Values "controller").image.repository }}:{{ (index .Values "controller").image.tag | toString }}
           imagePullPolicy: {{ (index .Values "controller").image.pullPolicy }}
           name: tembo-controller
-          {{- with (index .Values "controller").extraEnv }}
           env:
+            {{- with (index .Values "controller").env }}
+            {{- range . }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with (index .Values "controller").extraEnv }}
             {{- range . }}
             - name: {{ .name }}
               value: {{ tpl (.value | quote) $ }}
             {{- end }}
-          {{- end }}
+            {{- end }}
           {{- if (index .Values "controller").resources }}
           resources:
             {{- toYaml (index .Values "controller").resources | nindent 12 }}

--- a/charts/tembo-operator/values.yaml
+++ b/charts/tembo-operator/values.yaml
@@ -50,6 +50,15 @@ controller:
       port: http
       path: /metrics
 
+  # -- Set default env values currently used by the controller.
+  env:
+    # -- ENABLE_BACKUP will enable backups to object store (S3)
+    - name: ENABLE_BACKUP
+      value: "true"
+    # -- ENABLE_VOLUME_SNAPSHOT enables the use of external-snapshotter controller.  Requires VolumeSnapshot and VolumeSnapshotContent CRDs from external-snapshotter.
+    - name: ENABLE_VOLUME_SNAPSHOT
+      value: "false"
+
   extraEnv: []
 
   # -- Annotations to be added to the deployment

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.39.0"
+version = "0.39.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.39.2"
+version = "0.40.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.39.2"
+version = "0.40.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.39.1"
+version = "0.39.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/config.rs
+++ b/tembo-operator/src/config.rs
@@ -3,12 +3,16 @@ use std::env;
 #[derive(Clone, Debug)]
 pub struct Config {
     pub enable_backup: bool,
+    pub enable_volume_snapshot: bool,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             enable_backup: from_env_default("ENABLE_BACKUP", "true").parse().unwrap(),
+            enable_volume_snapshot: from_env_default("ENABLE_VOLUME_SNAPSHOT", "false")
+                .parse()
+                .unwrap(),
         }
     }
 }


### PR DESCRIPTION
* Update match on snapshot annotation from `cnpg.io/backupEndTime` to `cnpg.io/snapshotEndTime`.  `cnpg.io/backupEndTime` is only on the latest snapshot and not the others.
* Add configuration option in the operator to enable `VolumeSnapshots`, default is `false`
* Update `tembo-operator` Helm chart to include the `ENABLE_BACKUP` and `ENABLE_VOLUME_SNAPSHOT` config options.

fixes: [TEM-3282](https://linear.app/tembo/issue/TEM-3282/in-coredb-when-running-a-restore-via-snapshots-volumesnapshot-is-null)