### PR TITLE
Fix timeseries extension name

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.39.1"
+version = "0.40.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/stacks/templates/timeseries.yaml
+++ b/tembo-operator/src/stacks/templates/timeseries.yaml
@@ -75,7 +75,7 @@ postgres_config:
   - name: wal_level
     value: logical
 trunk_installs:
-  - name: timeseries
+  - name: pg_timeseries
     version: 0.1.1
   - name: pg_partman
     version: 5.0.1

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -44,6 +44,7 @@ impl std::str::FromStr for StackType {
             "OLTP" => Ok(StackType::OLTP),
             "RAG" => Ok(StackType::RAG),
             "Standard" => Ok(StackType::Standard),
+            "Timeseries" => Ok(StackType::Timeseries),
             "VectorDB" => Ok(StackType::VectorDB),
             _ => Err("invalid value"),
         }
@@ -249,6 +250,7 @@ mod tests {
             StackType::OLTP,
             StackType::RAG,
             StackType::Standard,
+            StackType::Timeseries,
             StackType::VectorDB,
         ];
 

--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b86ca0d6fe39c450aa51c5a24f87e6e7af939f913a312c55b155a7dc8eb8a64"
+checksum = "76fba296f889c8a03dc7ddd8e6f38d67151a6be024f32a6c0c89d78b96c85cf2"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.3.16"
+version = "0.3.18"
 dependencies = [
  "anyhow",
  "controller",


### PR DESCRIPTION
The name of the project as installed by trunk is pg_timeseries, while
"timeseries" is the extension name within PostgreSQL.
