### PR TITLE
Add tembo-stacks test, update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,4 @@ conductor/** @sjmiller609 @nhudson @ianstanton @ChuckHend
 tembo-pod-init/** @nhudson
 tembo-cli/** @shahadarsh @vrmiguel @DarrenBaldwin07 @sjmiller609
 tembo-py/** @chuckhend @EvanHStanton
+tembo-stacks/** @chuckhend @jasonmp85

--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -1996,6 +1996,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "indexmap 2.2.2",
  "itoa",
@@ -2219,6 +2225,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,7 +2303,10 @@ dependencies = [
  "lazy_static",
  "schemars",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "strum",
+ "strum_macros",
  "tracing",
  "utoipa",
 ]

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -19,3 +19,8 @@ serde_yaml = "0.9.21"
 tembo-controller = { package = "controller", version = "0.41.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }
+
+[dev-dependencies]
+strum = "0.26.2"
+strum_macros = "0.26.2"
+serde_json = "1.0.114"

--- a/tembo-stacks/src/stacks/types.rs
+++ b/tembo-stacks/src/stacks/types.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+#[cfg_attr(test, derive(strum_macros::EnumIter, strum_macros::Display))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub enum StackType {
     API,
@@ -63,6 +64,7 @@ impl StackType {
 #[cfg(test)]
 mod tests {
     use crate::stacks::{get_stack, types::StackType};
+    use strum::IntoEnumIterator;
     use tembo_controller::apis::postgres_parameters::PgConfig;
     use tembo_controller::stacks::types::Infrastructure;
 
@@ -118,26 +120,7 @@ mod tests {
 
     #[test]
     fn test_all_stack_deserialization() {
-        // must not panic when reading any stack definitions from yaml
-        let all_stacks = vec![
-            StackType::API,
-            StackType::DataWarehouse,
-            StackType::Geospatial,
-            StackType::MachineLearning,
-            StackType::MessageQueue,
-            StackType::MongoAlternative,
-            StackType::OLAP,
-            StackType::OLTP,
-            StackType::RAG,
-            StackType::Standard,
-            StackType::Timeseries,
-            StackType::VectorDB,
-        ];
-
-        for stack in all_stacks {
-            // this is overly verbose, but we want to ensure each Stack can be deserialized from yaml
-            // pattern match on the StackType enum, which if a new stack is added, this test will fail until its updated
-            // guarantees all StackTypes are tested
+        for stack in StackType::iter() {
             match stack {
                 StackType::API => {
                     get_stack(StackType::API);
@@ -176,6 +159,20 @@ mod tests {
                     get_stack(StackType::VectorDB);
                 }
             }
+        }
+    }
+
+    #[test]
+    fn test_all_stack_variants() {
+        for variant in StackType::iter() {
+            let stack_str = variant.as_str();
+            // from string back to StackType
+            let stack_type = stack_str.parse::<StackType>();
+            assert!(
+                stack_type.is_ok(),
+                "stack type missing from_str {:?}",
+                stack_str
+            )
         }
     }
 }


### PR DESCRIPTION
Adds a test that covers the `from_str` arms on `StackType`. Added dev-dependencies for those tests.