### PR TITLE
fix logic to not update Backup during an update event

### DIFF
--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -17,7 +17,6 @@ futures = "0.3.28"
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"] }
 log = "0.4.17"
 pgmq = "0.16.1"
-rand = "0.8"
 schemars = "0.8.12"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"

--- a/conductor/src/errors.rs
+++ b/conductor/src/errors.rs
@@ -45,7 +45,4 @@ pub enum ConductorError {
 
     #[error("Name or Namespace was not for for: {0}")]
     NameOrNamespaceNotFound(String),
-
-    #[error("CoreDB spec not found for: {0}")]
-    CoreDBSpecNotFound(String),
 }

--- a/conductor/src/errors.rs
+++ b/conductor/src/errors.rs
@@ -46,6 +46,6 @@ pub enum ConductorError {
     #[error("Name or Namespace was not for for: {0}")]
     NameOrNamespaceNotFound(String),
 
-    #[error("CoreDB Restore spec not found for: {0}")]
-    CoreDBRestoreSpecNotFound(String),
+    #[error("CoreDB spec not found for: {0}")]
+    CoreDBSpecNotFound(String),
 }

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -478,7 +478,7 @@ async fn get_stack_outputs(
     Ok(stack_outputs)
 }
 
-pub async fn generate_rand_schedule() -> String {
+pub fn generate_rand_schedule() -> String {
     // Generate a random minute and hour between 4am and 10am UTC
     let mut rng = rand::thread_rng();
     let minute: u8 = rng.gen_range(0..60);

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -649,110 +649,36 @@ async fn init_cloud_perms(
     });
 
     // Format Backup spec in CoreDBSpec
-    let backup = Backup {
-        destinationPath: Some(format!(
-            "s3://{}/coredb/{}/org-{}-inst-{}",
-            backup_archive_bucket,
-            &read_msg.message.organization_name,
-            &read_msg.message.organization_name,
-            &read_msg.message.dbname
-        )),
-        encryption: Some(String::from("AES256")),
-        retentionPolicy: Some(String::from("30")),
-        schedule: Some(generate_rand_schedule().await),
-        s3_credentials: Some(S3Credentials {
-            inherit_from_iam_role: Some(true),
+    // If read_msg.message.event_type is Event::Update we want to use the existing backup
+    // configuration spec
+    if read_msg.message.event_type == Event::Update {
+        // Since Backup is always present, there's no need to clone it for an update.
+        // Just return here since we are not updating anything.
+    } else {
+        // Directly assign a new Backup object to coredb_spec.backup for non-Update events
+        coredb_spec.backup = Backup {
+            destinationPath: Some(format!(
+                "s3://{}/coredb/{}/org-{}-inst-{}",
+                backup_archive_bucket,
+                &read_msg.message.organization_name,
+                &read_msg.message.organization_name,
+                &read_msg.message.dbname
+            )),
+            encryption: Some(String::from("AES256")),
+            retentionPolicy: Some(String::from("30")),
+            schedule: Some(generate_rand_schedule()),
+            s3_credentials: Some(S3Credentials {
+                inherit_from_iam_role: Some(true),
+                ..Default::default()
+            }),
+            volume_snapshot,
             ..Default::default()
-        }),
-        volume_snapshot,
-        ..Default::default()
-    };
-
-    // // if read_msg.message.event_type is Event::Restore, we want to append the restore
-    // // spec to possibly enable volumeSnapshots
-    // if read_msg.message.event_type == Event::Restore {
-    //     let namespace = read_msg
-    //         .message
-    //         .spec
-    //         .as_ref()
-    //         .and_then(|spec| spec.restore.as_ref())
-    //         .map(|restore| &restore.server_name)
-    //         .ok_or_else(|| {
-    //             ConductorError::NameOrNamespaceNotFound("Namespace not found".to_string())
-    //         })?;
-    //     // Lookup the CoreDB of the instance we are restoring from
-    //     let restore_spec = lookup_coredb(client.clone(), namespace).await?;
-    //
-    //     // Check if volume snapshots are enabled on the CoreDBSpec we are restoring from
-    //     // use volume_snapshot_enabled feature flag to only enable for specific org_id's
-    //     let volume_snapshot_enabled = is_volume_snapshot_enabled(read_msg, &restore_spec);
-    //
-    //     info!(
-    //         "Volume snapshot restore is {} for instance_id {} in org_id: {}",
-    //         volume_snapshot_enabled, read_msg.message.inst_id, read_msg.message.org_id
-    //     );
-    //
-    //     // Ensure a restore spec exists, otherwise return an error
-    //     let restore =
-    //         coredb_spec
-    //             .restore
-    //             .as_mut()
-    //             .ok_or(ConductorError::CoreDBRestoreSpecNotFound(
-    //                 namespace.to_string(),
-    //             ))?;
-    //
-    //     // Set volume_snapshot based on the determined value
-    //     info!(
-    //         "Restore from volume snapshot in namespace: {} {}",
-    //         namespace, volume_snapshot_enabled
-    //     );
-    //     restore.volume_snapshot = Some(volume_snapshot_enabled);
-    // }
-
-    coredb_spec.backup = backup;
+        };
+    }
     coredb_spec.serviceAccountTemplate = service_account_template;
 
     Ok(())
 }
-
-// For restore events we need to lookup the CoreDB of the instance we are restoring from
-// to check if volume snapshots are enabled. If they are we need to enable them on the
-// CoreDB we are restoring to.
-// async fn lookup_coredb(client: Client, namespace: &str) -> Result<CoreDBSpec, ConductorError> {
-//     let spec = get_one(client, namespace).await;
-//     match spec {
-//         Ok(s) => Ok(s.spec),
-//         Err(e) => Err(e),
-//     }
-// }
-
-// is_volume_snapshot_enabled is a glorified feature flag for volume snapshot restore
-// if the org_id matches from the list then we return true, else we return false.
-// fn is_volume_snapshot_enabled(msg: &Message<CRUDevent>, cdb_spec: &CoreDBSpec) -> bool {
-//     // Set a list of org_id's that are allowed to use volume snapshots
-//     // We need to set orgs in dev, staging and prod to use volume snapshots
-//     // tembo-test prod: org_2UJ2WPYFsE42Cos6mlmIuwIIJ4V
-//     // tembo-test dev/staging: org_2YW4TYIMI1LeOqJTXIyvkHOHCUo
-//     let orgs = ["org_2YW4TYIMI1LeOqJTXIyvkHOHCUo"];
-//
-//     if orgs.contains(&msg.message.org_id.as_str()) {
-//         info!(
-//             "Volume snapshot restore enabled for instance_id {} in org_id: {}",
-//             msg.message.inst_id, msg.message.org_id
-//         );
-//         cdb_spec
-//             .backup
-//             .volume_snapshot
-//             .as_ref()
-//             .map_or(false, |vs| vs.enabled)
-//     } else {
-//         info!(
-//             "Volume snapshot restore disabled for instance_id {} in org_id: {}",
-//             msg.message.inst_id, msg.message.org_id
-//         );
-//         false
-//     }
-// }
 
 fn from_env_default(key: &str, default: &str) -> String {
     env::var(key).unwrap_or_else(|_| default.to_owned())

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -651,10 +651,7 @@ async fn init_cloud_perms(
     // Format Backup spec in CoreDBSpec
     // If read_msg.message.event_type is Event::Update we want to use the existing backup
     // configuration spec
-    if read_msg.message.event_type == Event::Update {
-        // Since Backup is always present, there's no need to clone it for an update.
-        // Just return here since we are not updating anything.
-    } else {
+    if read_msg.message.event_type != Event::Update {
         // Directly assign a new Backup object to coredb_spec.backup for non-Update events
         coredb_spec.backup = Backup {
             destinationPath: Some(format!(

--- a/conductor/tests/integration_tests.rs
+++ b/conductor/tests/integration_tests.rs
@@ -248,6 +248,8 @@ mod test {
             locations: vec![install_location],
         });
         let num_expected_extensions = spec.extensions.len();
+        // Get the current CoreDB spec
+        let current_coredb = coredb_resource.clone();
         // println!("Updated spec: {:?}", spec.clone());
         let msg = types::CRUDevent {
             organization_name: org_name.clone(),
@@ -302,6 +304,20 @@ mod test {
         };
 
         println!("start_time: {:?}", stdout);
+
+        // Since we have updated lets check the status of the CoreDB from current_coredb
+        let update_coredb = coredb_api.get(&namespace).await.unwrap();
+        let old_backup_spec = current_coredb.spec.backup.clone();
+        let new_backup_spec = update_coredb.spec.backup.clone();
+
+        // assert that the backup.schedule for old_backup_spec are equal to new_backup_spec
+        assert_eq!(old_backup_spec.schedule, new_backup_spec.schedule);
+
+        // assert that the destination paths for old_backup_spec are equal to new_backup_spec
+        assert_eq!(
+            old_backup_spec.destinationPath,
+            new_backup_spec.destinationPath
+        );
 
         // Lets now test sending an Event::Restart to the queue and see if the
         // pod restarts correctly.


### PR DESCRIPTION
There is an issue where some `CoreDB`'s are being updated every 2-3 minutes and their backup schedules are changing.  This is causing backups to be taken multiple times an hour.

* Fix logic to not update the `CoreDBSpec.Backup` section on an `Event::Update`.
* Fix `generate_rand_schedule()` function to be non-async as it's not doing any async functionality
* Cleanup old commented out code.