### PR TITLE
convert the ttl for reconciles to a config option

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.41.1"
+version = "0.41.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/config.rs
+++ b/tembo-operator/src/config.rs
@@ -4,6 +4,8 @@ use std::env;
 pub struct Config {
     pub enable_backup: bool,
     pub enable_volume_snapshot: bool,
+    pub reconcile_timestamp_ttl: u64,
+    pub reconcile_ttl: u64,
 }
 
 impl Default for Config {
@@ -13,6 +15,12 @@ impl Default for Config {
             enable_volume_snapshot: from_env_default("ENABLE_VOLUME_SNAPSHOT", "false")
                 .parse()
                 .unwrap(),
+            // The time to live for recociling the reconcile timestamp
+            reconcile_timestamp_ttl: from_env_default("RECONCILE_TIMESTAMP_TTL", "30")
+                .parse()
+                .unwrap(),
+            // The time to live for reconciling the entire instance
+            reconcile_ttl: from_env_default("RECONCILE_TTL", "90").parse().unwrap(),
         }
     }
 }

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -341,7 +341,7 @@ impl CoreDB {
             };
             // Update the timestamp if it's been more than 30 seconds since the last update
             if current_fully_reconciled_at.map_or(true, |last_reconciled| {
-                current_time > last_reconciled + Duration::from_secs(30)
+                current_time > last_reconciled + Duration::from_secs(cfg.reconcile_timestamp_ttl)
             }) {
                 Some(current_time)
             } else {
@@ -363,7 +363,9 @@ impl CoreDB {
         info!("Fully reconciled {}", self.name_any());
         // Check back every 90-150 seconds
         let jitter = rand::thread_rng().gen_range(0..60);
-        Ok(Action::requeue(Duration::from_secs(90 + jitter)))
+        Ok(Action::requeue(Duration::from_secs(
+            cfg.reconcile_ttl + jitter,
+        )))
     }
 
     // enable_volume_snapshot makes sure that the CoreDB spec has the spec.backup.volumeSnapshot


### PR DESCRIPTION
Due to a very high umber of reconciles at a time, we need to space out the timings.  This PR moves the ttl values to be configurable while keeping the default values that were already set.

* New values 
  * `RECONCILE_TIMESTAMP_TTL`: default `30` seconds - The duration to check to update the last reconciled time
  * `RECONCILE_TTL`: default `90` seconds - The duration to wait to run a full reconcile.

fixes: [TEM-3299](https://linear.app/tembo/issue/TEM-3299/high-cpu-usage-on-operator-in-prod)