### PR TITLE
ensure that the cnpg_pooler_pgbouncer has correct schema permissions

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.41.2"
+version = "0.41.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1434,6 +1434,15 @@ BEGIN
     END LOOP;
     CLOSE db_list;
 
+    -- Check and grant USAGE privilege on the public schema if not already granted
+    IF NOT EXISTS (
+        SELECT 1 
+        FROM information_schema.role_usage_grants 
+        WHERE grantee = 'cnpg_pooler_pgbouncer' AND object_schema = 'public' AND privilege_type = 'USAGE'
+    ) THEN
+        EXECUTE 'GRANT USAGE ON SCHEMA public TO cnpg_pooler_pgbouncer;';
+    END IF;
+
     -- Check if the function exists, if not create it
     IF NOT EXISTS (
         SELECT 1

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -5018,6 +5018,16 @@ CREATE EVENT TRIGGER pgrst_watch
         )
         .await;
 
+        // Query the database to make sure the pgbouncer role has usage privilege
+        let _usage_privilege_result = wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "SELECT has_schema_privilege('cnpg_pooler_pgbouncer', 'public', 'USAGE') AS has_usage_permission;".to_string(),
+            "t".to_string(),
+            false,
+        )
+        .await;
+
         // Update coredb to disable pooler
         let _coredb_json = serde_json::json!({
             "apiVersion": API_VERSION,


### PR DESCRIPTION
Ensure that the `cnpg_pooler_pgbouncer` role has correct `public` schema permissions.

fixes: [PLAT-111](https://linear.app/tembo/issue/PLAT-111/ensure-schema-permission-to-bouncer)