### PR TITLE
Apply correct annotations to appsvc resources

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.41.3"
+version = "0.41.4"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.41.3"
+version = "0.41.4"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"


### PR DESCRIPTION
Make sure we apply the correct `annotations` to the AppService resources we deploy to the cluster.  This will allow Loki to pick up on the apps logs correctly.

Looking at the `promtail` configuration we need to propagate the `org_id` and `instance_id` of the `Pod` to have the logs scraped correctly.

fixes: [PLAT-87](https://linear.app/tembo/issue/PLAT-87/add-logs-for-app-services)