### PR TITLE
Rewrite org_id to organization_id for appsvc annotations

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.41.4"
+version = "0.41.5"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.41.4"
+version = "0.41.5"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -611,7 +611,15 @@ fn generate_appsvc_annotations(cdb: &CoreDB) -> BTreeMap<String, String> {
         |annotations| {
             annotations
                 .iter()
-                .map(|(k, v)| (k.clone(), v.clone()))
+                .map(|(k, v)| {
+                    if k == "tembo.io/org_id" {
+                        // Change key to "tembo.io/organization_id" if it matches "tembo.io/org_id"
+                        ("tembo.io/organization_id".to_string(), v.clone())
+                    } else {
+                        // Otherwise, clone the key and value as is
+                        (k.clone(), v.clone())
+                    }
+                })
                 .collect()
         },
     )
@@ -961,7 +969,7 @@ mod tests {
                 "inst_4836271985012_bZTnPq_85".to_string(),
             ),
             (
-                "tembo.io/org_id".to_string(),
+                "tembo.io/organization_id".to_string(),
                 "org_jQ7nBcX8uPzLkYdGtW1fvHOqMRST".to_string(),
             ),
         ]

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1436,8 +1436,8 @@ BEGIN
 
     -- Check and grant USAGE privilege on the public schema if not already granted
     IF NOT EXISTS (
-        SELECT 1 
-        FROM information_schema.role_usage_grants 
+        SELECT 1
+        FROM information_schema.role_usage_grants
         WHERE grantee = 'cnpg_pooler_pgbouncer' AND object_schema = 'public' AND privilege_type = 'USAGE'
     ) THEN
         EXECUTE 'GRANT USAGE ON SCHEMA public TO cnpg_pooler_pgbouncer;';
@@ -1469,7 +1469,7 @@ BEGIN
         EXECUTE 'REVOKE ALL ON FUNCTION user_search(text) FROM public;';
         EXECUTE 'GRANT EXECUTE ON FUNCTION user_search(text) TO cnpg_pooler_pgbouncer;';
     END IF;
-    
+
 END;
 $$;"#;
 
@@ -2584,7 +2584,7 @@ mod tests {
             schedule: 55 7 * * *
             volumeSnapshot:
               enabled: false
-          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e 
+          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
           port: 5432
           postgresExporterEnabled: true
           postgresExporterImage: quay.io/prometheuscommunity/postgres-exporter:v0.12.1
@@ -2879,7 +2879,7 @@ mod tests {
           name: test
           namespace: default
         spec:
-          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e 
+          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
           port: 5432
           postgresExporterEnabled: true
           postgresExporterImage: quay.io/prometheuscommunity/postgres-exporter:v0.12.1
@@ -2911,7 +2911,7 @@ mod tests {
           name: test
           namespace: default
         spec:
-          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e 
+          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
           port: 5432
           postgresExporterEnabled: true
           postgresExporterImage: quay.io/prometheuscommunity/postgres-exporter:v0.12.1
@@ -2951,7 +2951,7 @@ mod tests {
             volumeSnapshot:
               enabled: true
               snapshotClass: "csi-vsc"
-          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e 
+          image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
           port: 5432
           replicas: 1
           resources:


### PR DESCRIPTION
Make sure that the annotation`tembo.io/org_id` is rewritten to `tembo.io/organization_id`

Fixes: [PLAT-87](https://linear.app/tembo/issue/PLAT-87/add-logs-for-app-services)