### PR TITLE
Add `traefik` namespace selector to `allow-system-egress` NetworkPolicy

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.42.0"
+version = "0.42.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/network_policies.rs
+++ b/tembo-operator/src/network_policies.rs
@@ -172,6 +172,10 @@ pub async fn reconcile_network_policies(client: Client, namespace: &str) -> Resu
                 {
                   "protocol": "TCP",
                   "port": 443
+                },
+                {
+                  "protocol": "TCP",
+                  "port": 8443
                 }
               ]
             }

--- a/tembo-operator/src/network_policies.rs
+++ b/tembo-operator/src/network_policies.rs
@@ -155,13 +155,23 @@ pub async fn reconcile_network_policies(client: Client, namespace: &str) -> Resu
                       "kubernetes.io/metadata.name": "minio"
                     }
                   }
-                },
+                }
+              ]
+            },
+            {
+              "to": [
                 {
                   "namespaceSelector": {
                     "matchLabels": {
                       "kubernetes.io/metadata.name": "traefik"
                     }
                   }
+                }
+              ],
+              "ports": [
+                {
+                  "protocol": "TCP",
+                  "port": 443
                 }
               ]
             }

--- a/tembo-operator/src/network_policies.rs
+++ b/tembo-operator/src/network_policies.rs
@@ -155,6 +155,13 @@ pub async fn reconcile_network_policies(client: Client, namespace: &str) -> Resu
                       "kubernetes.io/metadata.name": "minio"
                     }
                   }
+                },
+                {
+                  "namespaceSelector": {
+                    "matchLabels": {
+                      "kubernetes.io/metadata.name": "traefik"
+                    }
+                  }
                 }
               ]
             }


### PR DESCRIPTION
Allow for components to reach services in `traefik` namespace. This is required for the pganalyze collector.