### PR TITLE
Update to Official `pganalyze/collector` Image

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "controller",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/apps/pganalyze.yaml
+++ b/tembo-stacks/src/apps/pganalyze.yaml
@@ -1,6 +1,6 @@
 name: !pganalyze
 appServices:
-  - image: quay.io/tembo/pganalyze-collector:0.54.0-alpha7
+  - image: quay.io/pganalyze/collector:v0.55.0
     name: pganalyze
     env:
       - name: DB_URL


### PR DESCRIPTION
The image for pganalyze [`v0.55.0`](https://github.com/pganalyze/collector/releases/tag/v0.55.0) has been released. Swapping out our test image for the official image.