### PR TITLE
Disable volume snapshot backups when setting CoreDB

### DIFF
--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -11,7 +11,6 @@ use conductor::{
 use controller::apis::coredb_types::{
     Backup, CoreDBSpec, S3Credentials, ServiceAccountTemplate, VolumeSnapshot,
 };
-use controller::cloudnativepg::VOLUME_SNAPSHOT_CLASS_NAME;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::Client;
 use log::{debug, error, info, warn};
@@ -705,10 +704,11 @@ async fn init_cloud_perms(
         }),
     };
 
+    // TODO: disbale volumesnapshots for now until we can make them work with CNPG
     // Enable VolumeSnapshots for all instances being created
     let volume_snapshot = Some(VolumeSnapshot {
-        enabled: true,
-        snapshot_class: Some(VOLUME_SNAPSHOT_CLASS_NAME.to_string()),
+        enabled: false,
+        snapshot_class: None,
     });
 
     let instance_name_slug = format!(


### PR DESCRIPTION
Disable `VolumeSnapshots` in backups for all `CoreDB`. 