### PR TITLE
make sure volumesnapshot is disabled

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.42.1"
+version = "0.43.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -728,8 +728,7 @@ async fn init_cloud_perms(
             inherit_from_iam_role: Some(true),
             ..Default::default()
         }),
-        // TODO: disbale volumesnapshots for now
-        // volume_snapshot,
+        volume_snapshot,
         ..Default::default()
     };
 


### PR DESCRIPTION
Make sure snapshots are disabled when setting `CoreDB`

fixes: [PLAT-435](https://linear.app/tembo/issue/PLAT-435/back-out-from-using-volume-snapshots)