### PR TITLE
Fix: Error when set to multiple environments

### DIFF
--- a/tembo-cli/src/cli/context.rs
+++ b/tembo-cli/src/cli/context.rs
@@ -134,7 +134,20 @@ pub fn list_context() -> Result<Option<Context>, anyhow::Error> {
     let maybe_context: Result<Context, toml::de::Error> = toml::from_str(&contents);
 
     match maybe_context {
-        Ok(context) => Ok(Some(context)),
+        Ok(mut context) => {
+            let mut count = 0;
+            for e in context.environment.iter_mut() {
+                if e.set == Some(true) {
+                    count += 1;
+                }
+            }
+
+            if count > 1 {
+                bail!("More than one environment is set to true. Check your context file");
+            } else {
+                Ok(Some(context))
+            }
+        }
         Err(err) => {
             eprintln!("\nInvalid context file {filename}\n");
 

--- a/tembo-cli/src/cmd/context/set.rs
+++ b/tembo-cli/src/cmd/context/set.rs
@@ -1,4 +1,4 @@
-use crate::cli::context::{tembo_context_file_path, Context};
+use crate::cli::context::{list_context, tembo_context_file_path, Context};
 use crate::tui::{colors, error};
 use anyhow::Error;
 use clap::Args;
@@ -15,6 +15,7 @@ pub struct ContextSetArgs {
 }
 
 pub fn execute(args: &ContextSetArgs) -> Result<(), anyhow::Error> {
+    let _ = list_context();
     let filename = tembo_context_file_path();
 
     let contents = match fs::read_to_string(&filename) {

--- a/tembo-cli/src/cmd/login.rs
+++ b/tembo-cli/src/cmd/login.rs
@@ -1,6 +1,6 @@
 use crate::cli::context::{
-    get_current_context, tembo_context_file_path, tembo_credentials_file_path, Context, Credential,
-    Environment,
+    get_current_context, list_context, tembo_context_file_path, tembo_credentials_file_path,
+    Context, Credential, Environment,
 };
 use crate::tui::error;
 use actix_cors::Cors;
@@ -43,6 +43,7 @@ struct TokenRequest {
 }
 
 pub fn execute(login_cmd: LoginCommand) -> Result<(), anyhow::Error> {
+    let _ = list_context();
     match (&login_cmd.organization_id, &login_cmd.profile) {
         (Some(_), None) | (None, Some(_)) => {
             return Err(anyhow!(


### PR DESCRIPTION
Closes [Linear-356](https://linear.app/tembo/issue/PLAT-356/tembo-cli-context-set-to-multiple-environments)