### PR TITLE
Update gis stack spec.

### DIFF
--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.43.3"
+version = "0.43.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.43.2"
+version = "0.43.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/gis.yaml
+++ b/tembo-stacks/src/stacks/specs/gis.yaml
@@ -82,8 +82,6 @@ trunk_installs:
     version: 1.2.0
   - name: pg_stat_statements
     version: 1.10.0
-  - name: pointcloud
-    version: 1.2.5
 extensions:
   - name: pg_stat_statements
     locations:

--- a/tembo-stacks/src/stacks/specs/gis.yaml
+++ b/tembo-stacks/src/stacks/specs/gis.yaml
@@ -78,8 +78,12 @@ postgres_config:
   - name: shared_preload_libraries
     value: pg_stat_statements
 trunk_installs:
+  - name: fuzzystrmatch
+    version: 1.2.0
   - name: pg_stat_statements
     version: 1.10.0
+  - name: pointcloud
+    version: 1.2.5
 extensions:
   - name: pg_stat_statements
     locations:


### PR DESCRIPTION
## [tembo-stacks/Cargo.toml](https://github.com/tembo-io/tembo/pull/692/files#diff-3c9a183277ad933dc67601a6ffedab020ef231d9301611d051b3f166aefddb0a)
- Bump version of `tembo-stacks` package to `0.5.1`

## [tembo-stacks/src/stacks/specs/gis.yaml](https://github.com/tembo-io/tembo/pull/692/files#diff-790de6eaab371ca7eaf0e8dfa6f4cb618a782d27e7cf52b9c6cab1b982a67a5e)
- Add `fuzzystrmatch` extension to be trunk-installed by default in geospatial stack
