### PR TITLE
Fix message queue sample

### DIFF
--- a/tembo-operator/yaml/sample-message-queue.yaml
+++ b/tembo-operator/yaml/sample-message-queue.yaml
@@ -77,7 +77,7 @@ spec:
           - "postgres"
   runtime_config:
     - name: shared_buffers
-      value: "1024MB"
+      value: "512MB"
     - name: max_connections
       value: "431"
     - name: work_mem


### PR DESCRIPTION
The message queue sample yaml fails to apply with the following error:
```
2024-04-02T13:05:54.645148Z ERROR reconciling object:reconcile:reconcile:reconcile_cnpg: controller::cloudnativepg::cnpg:1160: Error patching cluster: ApiError: admission webhook "vcluster.cnpg.io" denied the request: Cluster.postgresql.cnpg.io "sample-message-queue" is invalid: spec.resources.requests.memory: Invalid value: "512Mi": Memory request is lower than PostgreSQL `shared_buffers` value: Invalid (ErrorResponse { status: "Failure", message: "admission webhook \"vcluster.cnpg.io\" denied the request: Cluster.postgresql.cnpg.io \"sample-message-queue\" is invalid: spec.resources.requests.memory: Invalid value: \"512Mi\": Memory request is lower than PostgreSQL `shared_buffers` value", reason: "Invalid", code: 422 }) object.ref=CoreDB.v1alpha1.coredb.io/sample-message-queue.default object.reason=reconciler requested retry trace_id=00000000000000000000000000000000 instance_name=sample-message-queue
```

This PR resolves the issue.