### PR TITLE
add kubernetes 429 error requeue with jitter

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.43.2"
+version = "0.44.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.43.2"
+version = "0.44.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"
@@ -61,6 +61,7 @@ hyper = "0.14.27"
 rand = "0.8.5"
 tower-test = "0.4.0"
 futures-util = "0.3"
+regex = "1"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive", "ws"]


### PR DESCRIPTION
Add error handling in the client to requeue differently when a 429 is returned back from the server.

* Added two new tests to mock the Kubernetes API to test a 429 return code and a non 429 return code.

Fixes: [PLAT-497](https://linear.app/tembo/issue/PLAT-497/handle-kube-api-429-with-requeue)