### PR TITLE
If issuing a restart or updating an image, do that first before applying anything else.

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.44.0"
+version = "0.44.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg_utils.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg_utils.rs
@@ -1,0 +1,259 @@
+use crate::{
+    apis::coredb_types::CoreDB, cloudnativepg::clusters::Cluster,
+    extensions::database_queries::is_not_restarting, patch_cdb_status_merge, Context, RESTARTED_AT,
+};
+use kube::{
+    api::{Patch, PatchParams},
+    runtime::controller::Action,
+    Api, ResourceExt,
+};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::time::Duration;
+use tracing::{debug, error, info, instrument, warn};
+
+// restart_and_wait_for_restart is a synchronous function that takes a CNPG cluster adds the restart annotation
+// and waits for the restart to complete.
+#[instrument(skip(cdb, ctx, prev_cluster), fields(trace_id, instance_name = %cdb.name_any()))]
+pub(crate) async fn restart_and_wait_for_restart(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+    prev_cluster: Option<&Cluster>,
+) -> Result<(), Action> {
+    // Check if prev_cluster is None, if so return early
+    if prev_cluster.is_none() {
+        warn!("No previous cluster found for {}", cdb.name_any());
+        return Ok(());
+    }
+
+    let Some(cdb_restarted_at) = cdb.annotations().get(RESTARTED_AT) else {
+        // No need to update the annotation if it's not present in the CoreDB
+        warn!("No restart annotation found for {}", cdb.name_any());
+        return Ok(());
+    };
+
+    // Get the previous value of the annotation, if any
+    let previous_restarted_at =
+        prev_cluster.and_then(|cluster| cluster.annotations().get(RESTARTED_AT));
+
+    let restart_annotation_updated = previous_restarted_at != Some(cdb_restarted_at);
+    debug!(
+        "Restart annotation updated: {} for instance: {}",
+        restart_annotation_updated,
+        cdb.name_any()
+    );
+
+    if restart_annotation_updated {
+        warn!(
+            "Restarting instance: {} with restart annotation: {}",
+            cdb.name_any(),
+            cdb_restarted_at
+        );
+
+        let restart_patch = json!({
+            "metadata": {
+                "annotations": {
+                    RESTARTED_AT: cdb_restarted_at,
+                }
+            }
+        });
+
+        patch_cluster_merge(cdb, &ctx, restart_patch).await?;
+        update_coredb_status(cdb, &ctx, false).await?;
+
+        info!(
+            "Updated status.running to false in {}, requeuing 10 seconds",
+            &cdb.name_any()
+        );
+
+        let restart_complete_time = is_not_restarting(cdb, ctx.clone(), "postgres").await?;
+
+        info!(
+            "Restart time is {:?} for instance: {}",
+            restart_complete_time,
+            &cdb.name_any()
+        );
+    }
+
+    let cdb_api: Api<CoreDB> =
+        Api::namespaced(ctx.client.clone(), cdb.metadata.namespace.as_ref().unwrap());
+    let coredb_status = cdb_api.get(&cdb.name_any()).await.map_err(|e| {
+        error!("Error retrieving CoreDB status: {}", e);
+        Action::requeue(Duration::from_secs(300))
+    })?;
+
+    if let Some(status) = coredb_status.status {
+        if !status.running {
+            update_coredb_status(cdb, &ctx, true).await?;
+            info!(
+                "Updated CoreDB status.running to true for instance: {}",
+                &cdb.name_any()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument(skip(cdb, ctx), fields(trace_id, instance_name = %cdb.name_any(), running = %running))]
+async fn update_coredb_status(
+    cdb: &CoreDB,
+    ctx: &Arc<Context>,
+    running: bool,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+    let namespace = cdb.metadata.namespace.as_ref().ok_or_else(|| {
+        error!("Namespace is empty for instance: {}.", name);
+        Action::requeue(Duration::from_secs(300))
+    })?;
+
+    let cdb_api: Api<CoreDB> = Api::namespaced(ctx.client.clone(), namespace);
+    patch_cdb_status_merge(
+        &cdb_api,
+        &name,
+        json!({
+            "status": {
+                "running": running
+            }
+        }),
+    )
+    .await
+}
+
+// patch_cluster_merge takes a CoreDB, Cluster and serde_json::Value and patch merges the Cluster with the new spec
+#[instrument(skip(cdb, ctx), fields(trace_id, instance_name = %cdb.name_any(), patch = %patch))]
+async fn patch_cluster_merge(
+    cdb: &CoreDB,
+    ctx: &Arc<Context>,
+    patch: serde_json::Value,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+    let namespace = cdb.metadata.namespace.as_ref().ok_or_else(|| {
+        error!("Namespace is empty for instance: {}.", name);
+        Action::requeue(Duration::from_secs(300))
+    })?;
+
+    let cluster_api: Api<Cluster> = Api::namespaced(ctx.client.clone(), namespace);
+    let pp = PatchParams::apply("restart_annotation_patch");
+    let _ = cluster_api
+        .patch(&name, &pp, &Patch::Merge(&patch))
+        .await
+        .map_err(|e| {
+            error!("Error patching cluster: {}", e);
+            Action::requeue(Duration::from_secs(300))
+        });
+
+    Ok(())
+}
+
+// cdb: the CoreDB object
+// maybe_cluster, Option<Cluster> of the current CNPG cluster, if it exists
+// new_spec: the new Cluster spec to be applied
+#[instrument(skip(cdb, maybe_cluster, new_spec), fields(trace_id, instance_name = %cdb.name_any()))]
+pub(crate) fn update_restarted_at(
+    cdb: &CoreDB,
+    maybe_cluster: Option<&Cluster>,
+    new_spec: &mut Cluster,
+) -> bool {
+    let Some(cdb_restarted_at) = cdb.annotations().get(RESTARTED_AT) else {
+        // No need to update the annotation if it's not present in the CoreDB
+        return false;
+    };
+
+    // Remember the previous value of the annotation, if any
+    let previous_restarted_at =
+        maybe_cluster.and_then(|cluster| cluster.annotations().get(RESTARTED_AT));
+
+    // Forward the `restartedAt` annotation from CoreDB over to the CNPG cluster,
+    // does not matter if changed or not.
+    new_spec
+        .metadata
+        .annotations
+        .as_mut()
+        .map(|cluster_annotations| {
+            cluster_annotations.insert(RESTARTED_AT.into(), cdb_restarted_at.to_owned())
+        });
+
+    let restart_annotation_updated = previous_restarted_at != Some(cdb_restarted_at);
+
+    if restart_annotation_updated {
+        let name = new_spec.metadata.name.as_deref().unwrap_or("unknown");
+        info!("restartAt changed for cluster {name}, setting to {cdb_restarted_at}.");
+    }
+
+    restart_annotation_updated
+}
+
+// patch_cluster is a async function that takes a CNPG cluster and patch applys it with the new spec
+#[instrument(skip(cdb, ctx) fields(trace_id, instance_name = %cdb.name_any()))]
+pub(crate) async fn patch_cluster(
+    cluster: &Cluster,
+    ctx: Arc<Context>,
+    cdb: &CoreDB,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+    let namespace = cdb.metadata.namespace.as_ref().ok_or_else(|| {
+        error!("Namespace is empty for instance: {}.", name);
+        Action::requeue(tokio::time::Duration::from_secs(300))
+    })?;
+
+    // Setup patch parameters
+    let pp = PatchParams::apply("cntrlr").force();
+
+    // Setup cluster API
+    let api: Api<Cluster> = Api::namespaced(ctx.client.clone(), namespace);
+
+    info!("Applying Cluster for instance: {}", &name);
+    let _o = api
+        .patch(&name, &pp, &Patch::Apply(&cluster))
+        .await
+        .map_err(|e| {
+            error!("Error patching Cluster: {}", e);
+            Action::requeue(Duration::from_secs(300))
+        })?;
+
+    Ok(())
+}
+
+// is_image_updated function takes a CoreDB, Context and a Cluster and checks to see if the image needs to be updated
+#[instrument(skip(cdb, ctx, prev_cluster), fields(trace_id, instance_name = %cdb.name_any()))]
+pub(crate) async fn is_image_updated(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+    prev_cluster: Option<&Cluster>,
+) -> Result<(), Action> {
+    // Check if prev_cluster is None, if so return early
+    if prev_cluster.is_none() {
+        warn!("No previous cluster found for {}", cdb.name_any());
+        return Ok(());
+    }
+
+    // Check if the image is being updated, check prev_cluster spec.imageName if it's different than what's in cdb.spec.image
+    if let Some(prev_cluster) = prev_cluster {
+        let prev_image = prev_cluster.spec.image_name.as_deref();
+        let new_image = cdb.spec.image.as_str();
+
+        if let Some(prev_image) = prev_image {
+            if prev_image != new_image {
+                warn!(
+                    "Image updated for instance: {} from {} to {}",
+                    cdb.name_any(),
+                    prev_image,
+                    new_image
+                );
+
+                // Create JSON Patch
+                let patch = json!({
+                    "spec": {
+                        "imageName": new_image
+                    }
+                });
+
+                // Update Cluster with patch
+                patch_cluster_merge(cdb, &ctx, patch).await?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tembo-operator/src/cloudnativepg/mod.rs
+++ b/tembo-operator/src/cloudnativepg/mod.rs
@@ -2,6 +2,7 @@ pub mod backups;
 pub mod clusters;
 pub(crate) mod cnpg;
 // pub(crate) mod cnpg_backups;
+mod cnpg_utils;
 pub mod poolers;
 mod scheduledbackups;
 

--- a/tembo-operator/src/extensions/database_queries.rs
+++ b/tembo-operator/src/extensions/database_queries.rs
@@ -301,7 +301,7 @@ pub async fn is_not_restarting(
         Ok(Some(server_started_at))
     } else {
         // Server hasn't even started restarting yet
-        error!("Restart is not complete for {}, requeuing", cdb_name);
+        warn!("Restart is not complete for {}, requeuing", cdb_name);
         Err(Action::requeue(Duration::from_secs(5)))
     }
 }

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -693,6 +693,77 @@ mod test {
             metric_name, max_retries
         ))
     }
+    async fn wait_til_status_is_filled(coredbs: &Api<CoreDB>, name: &str) {
+        let max_retries = 10; // adjust as needed
+        for attempt in 1..=max_retries {
+            let coredb = coredbs
+                .get(name)
+                .await
+                .unwrap_or_else(|_| panic!("Failed to get CoreDB: {}", name));
+
+            if coredb.status.is_some() {
+                println!("Status is filled for CoreDB: {}", name);
+                return;
+            } else {
+                println!(
+                    "Attempt {}/{}: Status not yet filled for CoreDB: {}",
+                    attempt, max_retries, name
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+        panic!(
+            "Failed to fetch filled status for CoreDB: {} after {} attempts",
+            name, max_retries
+        );
+    }
+
+    async fn get_pg_start_time(
+        coredbs: &Api<CoreDB>,
+        name: &str,
+        ctx: Arc<Context>,
+    ) -> DateTime<Utc> {
+        const PG_TIMESTAMP_DECL: &str = "%Y-%m-%d %H:%M:%S.%f%#z";
+
+        let coredb = coredbs.get(name).await.expect("spec not found");
+
+        let query = "SELECT pg_postmaster_start_time()".to_string();
+        let psql_output = psql_with_retry(ctx.clone(), coredb, query).await;
+        let stdout = psql_output
+            .stdout
+            .as_ref()
+            .and_then(|stdout| stdout.lines().nth(2).map(str::trim))
+            .expect("expected stdout");
+
+        DateTime::parse_from_str(stdout, PG_TIMESTAMP_DECL)
+            .unwrap()
+            .into()
+    }
+
+    async fn status_running(coredbs: &Api<CoreDB>, name: &str) -> bool {
+        let max_retries = 10;
+        let wait_duration = Duration::from_secs(2); // Adjust as needed
+
+        for attempt in 1..=max_retries {
+            let coredb = coredbs.get(name).await.expect("Failed to get CoreDB");
+
+            if coredb.status.as_ref().map_or(false, |s| s.running) {
+                println!("CoreDB {} is running", name);
+                return true;
+            } else {
+                println!(
+                    "Attempt {}/{}: CoreDB {} is not running yet",
+                    attempt, max_retries, name
+                );
+            }
+            tokio::time::sleep(wait_duration).await;
+        }
+        println!(
+            "CoreDB {} did not become running after {} attempts",
+            name, max_retries
+        );
+        false
+    }
 
     #[tokio::test]
     #[ignore]
@@ -4981,77 +5052,6 @@ CREATE EVENT TRIGGER pgrst_watch
     #[tokio::test]
     #[ignore]
     async fn functional_test_restart_and_update_replicas() {
-        async fn wait_til_status_is_filled(coredbs: &Api<CoreDB>, name: &str) {
-            let max_retries = 10; // adjust as needed
-            for attempt in 1..=max_retries {
-                let coredb = coredbs
-                    .get(name)
-                    .await
-                    .unwrap_or_else(|_| panic!("Failed to get CoreDB: {}", name));
-
-                if coredb.status.is_some() {
-                    println!("Status is filled for CoreDB: {}", name);
-                    return;
-                } else {
-                    println!(
-                        "Attempt {}/{}: Status not yet filled for CoreDB: {}",
-                        attempt, max_retries, name
-                    );
-                }
-                tokio::time::sleep(Duration::from_secs(10)).await;
-            }
-            panic!(
-                "Failed to fetch filled status for CoreDB: {} after {} attempts",
-                name, max_retries
-            );
-        }
-
-        async fn get_pg_start_time(
-            coredbs: &Api<CoreDB>,
-            name: &str,
-            ctx: Arc<Context>,
-        ) -> DateTime<Utc> {
-            const PG_TIMESTAMP_DECL: &str = "%Y-%m-%d %H:%M:%S.%f%#z";
-
-            let coredb = coredbs.get(name).await.expect("spec not found");
-
-            let query = "SELECT pg_postmaster_start_time()".to_string();
-            let psql_output = psql_with_retry(ctx.clone(), coredb, query).await;
-            let stdout = psql_output
-                .stdout
-                .as_ref()
-                .and_then(|stdout| stdout.lines().nth(2).map(str::trim))
-                .expect("expected stdout");
-
-            DateTime::parse_from_str(stdout, PG_TIMESTAMP_DECL)
-                .unwrap()
-                .into()
-        }
-
-        async fn status_running(coredbs: &Api<CoreDB>, name: &str) -> bool {
-            let max_retries = 10;
-            let wait_duration = Duration::from_secs(2); // Adjust as needed
-
-            for attempt in 1..=max_retries {
-                let coredb = coredbs.get(name).await.expect("Failed to get CoreDB");
-
-                if coredb.status.as_ref().map_or(false, |s| s.running) {
-                    println!("CoreDB {} is running", name);
-                    return true;
-                } else {
-                    println!(
-                        "Attempt {}/{}: CoreDB {} is not running yet",
-                        attempt, max_retries, name
-                    );
-                }
-                tokio::time::sleep(wait_duration).await;
-            }
-            println!(
-                "CoreDB {} did not become running after {} attempts",
-                name, max_retries
-            );
-            false
-        }
         // Initialize the Kubernetes client
         let client = kube_client().await;
         let state = State::default();
@@ -5179,6 +5179,211 @@ CREATE EVENT TRIGGER pgrst_watch
             "start time should've changed"
         );
 
+        // Cleanup CoreDB
+        coredbs.delete(name, &Default::default()).await.unwrap();
+        println!("Waiting for CoreDB to be deleted: {}", &name);
+        let _assert_coredb_deleted = tokio::time::timeout(
+            Duration::from_secs(TIMEOUT_SECONDS_COREDB_DELETED),
+            await_condition(coredbs.clone(), name, conditions::is_deleted("")),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "CoreDB {} was not deleted after waiting {} seconds",
+                name, TIMEOUT_SECONDS_COREDB_DELETED
+            )
+        });
+        println!("CoreDB resource deleted {}", name);
+
+        // Delete namespace
+        let _ = delete_namespace(client.clone(), &namespace).await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn functional_test_cnpg_update_image_and_params() {
+        // Initialize the Kubernetes client
+        let client = kube_client().await;
+        let state = State::default();
+        let context = state.create_context(client.clone());
+
+        // Configurations
+        let mut rng = rand::thread_rng();
+        let suffix = rng.gen_range(0..100000);
+        let name = &format!("test-cnpg-upimage-{}", suffix);
+        let namespace = match create_namespace(client.clone(), name).await {
+            Ok(namespace) => namespace,
+            Err(e) => {
+                eprintln!("Error creating namespace: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        let kind = "CoreDB";
+        let replicas = 1;
+
+        // Create a pod we can use to run commands in the cluster
+        let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+
+        // Apply a basic configuration of CoreDB
+        println!("Creating CoreDB resource {}", name);
+        let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
+        // Generate CoreDB resource with params
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "replicas": replicas,
+            }
+        });
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let _coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        // Wait for CNPG Pod to be created
+        {
+            let pod_name = format!("{}-1", name);
+
+            pod_ready_and_running(pods.clone(), pod_name.clone()).await;
+            wait_til_status_is_filled(&coredbs, name).await;
+        }
+
+        // Ensure status.running is true
+        assert!(status_running(&coredbs, name).await);
+
+        // Update CNPG image and params
+        let coredb_json = serde_json::json!({
+            "apiVersion": API_VERSION,
+            "kind": kind,
+            "metadata": {
+                "name": name
+            },
+            "spec": {
+                "image": "quay.io/tembo/standard-cnpg:15-120cc24",
+                "replicas": replicas,
+                "trunk_installs": [
+                    {
+                        "name": "pg_partman",
+                        "version": "4.7.3",
+                    },
+                    {
+                        "name": "pgmq",
+                        "version": "1.1.1",
+                    },
+                    {
+                        "name": "pg_stat_statements",
+                        "version": "1.10.0",
+                    },
+                    {
+                        "name": "postgis",
+                        "version": "3.4.0",
+                    },
+                ],
+                "extensions": [
+                    {
+                        "name": "pg_partman",
+                        "locations": [
+                        {
+                          "enabled": true,
+                          "version": "4.7.3",
+                          "database": "postgres",
+                          "schema": "public"
+                        }]
+                    },
+                    {
+                        "name": "pgmq",
+                        "locations": [
+                        {
+                          "enabled": true,
+                          "version": "1.1.1",
+                          "database": "postgres",
+                          "schema": "public"
+                        }]
+                    },
+                    {
+                        "name": "pg_stat_statements",
+                        "locations": [
+                        {
+                          "enabled": true,
+                          "version": "1.10.0",
+                          "database": "postgres",
+                          "schema": "public"
+                        }]
+                    },
+                    {
+                        "name": "postgis",
+                        "locations": [
+                        {
+                          "enabled": true,
+                          "version": "3.4.0",
+                          "database": "postgres",
+                          "schema": "public"
+                        }]
+                    }
+                ],
+                "runtime_config": [
+                    {
+                        "name": "shared_preload_libraries",
+                        "value": "pg_stat_statements"
+                    },
+                    {
+                        "name": "pg_partman_bgw.interval",
+                        "value": "30"
+                    },
+                    {
+                        "name": "pg_partman_bgw.role",
+                        "value": "postgres"
+                    },
+                    {
+                        "name": "pg_partman_bgw.dbname",
+                        "value": "postgres"
+                    }
+                ]
+            }
+        });
+
+        // Use the patch method to update the Cluster resource
+        let params = PatchParams::apply("tembo-integration-test");
+        let patch = Patch::Apply(&coredb_json);
+        let coredb_resource = coredbs.patch(name, &params, &patch).await.unwrap();
+
+        let _result = wait_until_psql_contains(
+            context.clone(),
+            coredb_resource.clone(),
+            "show shared_preload_libraries;".to_string(),
+            "pg_partman_bgw".to_string(),
+            false,
+        )
+        .await;
+
+        // Assert that shared_preload_libraries contains pg_stat_statements
+        // and pg_partman_bgw
+
+        let result = psql_with_retry(
+            context.clone(),
+            coredb_resource.clone(),
+            "show shared_preload_libraries;".to_string(),
+        )
+        .await;
+
+        let stdout = match result.stdout {
+            Some(output) => output,
+            None => panic!("stdout is None"),
+        };
+
+        assert!(stdout.contains("pg_partman_bgw"));
+        assert!(stdout.contains("pg_stat_statements"));
+
+        //assert to make sure the correct image has been updated
+        let cluster_api: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
+        let cluster = cluster_api.get(name).await.unwrap();
+        let image = cluster.spec.image.clone();
+        assert_eq!(image, "quay.io/tembo/standard-cnpg:15-120cc24");
+
+        // CLEANUP TEST
         // Cleanup CoreDB
         coredbs.delete(name, &Default::default()).await.unwrap();
         println!("Waiting for CoreDB to be deleted: {}", &name);


### PR DESCRIPTION
This code change add handling if a restart is issued or if an image update is issued in the case where multiple values are being updated. 

For example if you issue a restart whist also updating another value in `CoreDB`, this will make sure that the restart is done first before doing anything else.  Also if you are updating the image it will apply the image update first before doing anything else.  It should negate seeing this error in the controller logs

```
2024-02-16T14:31:37.145986Z ERROR reconciling object:reconcile:reconcile:reconcile_cnpg: controller::cloudnativepg::cnpg:1079: Error patching cluster: ApiError: admission webhook "vcluster.cnpg.io" denied the request: Cluster.cluster.cnpg.io "org-v0idpwn-industries-inst-smol-tri" is invalid: spec.imageName: Invalid value: "387894460527.dkr.ecr.us-east-1.amazonaws.com/tembo-io/standard-cnpg:15-a0a5ab5": Can't change image name and configuration at the same time. There are differences in PostgreSQL configuration parameters: {"effective_io_concurrency":["","100"]}: Invalid (ErrorResponse { status: "Failure", message: "admission webhook \"vcluster.cnpg.io\" denied the request: Cluster.cluster.cnpg.io \"org-v0idpwn-industries-inst-smol-tri\" is invalid: spec.imageName: Invalid value: \"387894460527.dkr.ecr.us-east-1.amazonaws.com/tembo-io/standard-cnpg:15-a0a5ab5\": Can't change image name and configuration at the same time. There are differences in PostgreSQL configuration parameters: {\"effective_io_concurrency\":[\"\",\"100\"]}", reason: "Invalid", code: 422 }) object.ref=CoreDB.v1alpha1.coredb.io/org-v0idpwn-industries-inst-smol-tri.org-v0idpwn-industries-inst-smol-tri object.reason=reconciler requested retry trace_id=00000000000000000000000000000000 instance_name=org-v0idpwn-industries-inst-smol-tri
```

Fixes: [PLAT-539](https://linear.app/tembo/issue/PLAT-539/restart-annotation-causes-instances-stuck-fenced) & [PLAT-77](https://linear.app/tembo/issue/PLAT-77/fix-error-in-operator-with-changing-image-and-pg-config-simultaneously)