### PR TITLE
Publish `conductor` Helm Chart

### DIFF
--- a/.github/workflows/helm-release-conductor.yaml
+++ b/.github/workflows/helm-release-conductor.yaml
@@ -1,10 +1,10 @@
-name: Release Helm Chart
+name: Release conductor Helm Chart
 
 on:
   push:
     branches: [ "main" ]
     paths:
-      - 'charts/**'
+      - 'charts/conductor/**'
   workflow_dispatch:
 
 jobs:
@@ -29,12 +29,12 @@ jobs:
 
       - name: Package Helm Chart
         run: |
-          cd code/charts/tembo-operator
+          cd code/charts/conductor
           helm package .
 
       - name: Update Helm repo index
         run: |
-          mv code/charts/tembo-operator/*.tgz gh-pages/
+          mv code/charts/conductor/*.tgz gh-pages/
           cd gh-pages
           helm repo index . --merge index.yaml --url https://tembo-io.github.io/tembo
 

--- a/.github/workflows/helm-release-tembo-operator.yaml
+++ b/.github/workflows/helm-release-tembo-operator.yaml
@@ -1,0 +1,50 @@
+name: Release tembo-operator Helm Chart
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'charts/tembo-operator/**'
+  workflow_dispatch:
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          path: 'code'
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: 'gh-pages'
+          path: 'gh-pages'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3.5
+        with:
+          version: 3.13.2
+
+      - name: Package Helm Chart
+        run: |
+          cd code/charts/tembo-operator
+          helm package .
+
+      - name: Update Helm repo index
+        run: |
+          mv code/charts/tembo-operator/*.tgz gh-pages/
+          cd gh-pages
+          helm repo index . --merge index.yaml --url https://tembo-io.github.io/tembo
+
+      - name: Commit and Push
+        run: |
+          cd gh-pages
+          git config user.name "tembo-service-user"
+          git config user.email "admin+github@tembo.io"
+          git add .
+          git commit -m "Update Helm chart"
+          git push origin gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.SERVICE_USER_GITHUB_SSH_KEY }}


### PR DESCRIPTION
This PR adds a workflow for publishing the `conductor` helm chart to https://tembo-io.github.io/tembo. This allows us to reference this chart as a dependency in the [Tembo Enterprise](https://github.com/tembo-io/tembo-enterprise/) chart instead of duplicating that chart's YAML across repositories.

- Create a separate workflow for publishing the `conductor` helm chart on changes to `charts/conductor/**`
- Modify existing tembo-operator helm chart repo to publish on changes to `charts/tembo-operator/**`