### PR TITLE
Remove hard-coded `PG_CONN_URL` in Conductor Chart

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/conductor/templates/deployment.yaml
+++ b/charts/conductor/templates/deployment.yaml
@@ -39,11 +39,6 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-          - name: PG_CONN_URL
-            valueFrom:
-              secretKeyRef:
-                name: data-plane
-                key: _data-plane_postgres_connection_string
           - name: CONDUCTOR_ENABLED
             value: "true"
           - name: WATCHER_ENABLED

--- a/charts/conductor/templates/watcher-deployment.yaml
+++ b/charts/conductor/templates/watcher-deployment.yaml
@@ -39,11 +39,6 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
-          - name: PG_CONN_URL
-            valueFrom:
-              secretKeyRef:
-                name: data-plane
-                key: _data-plane_postgres_connection_string
           - name: CONDUCTOR_ENABLED
             value: "false"
           - name: WATCHER_ENABLED

--- a/charts/conductor/values.yaml
+++ b/charts/conductor/values.yaml
@@ -50,4 +50,9 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
-env: {}
+env:
+  - name: PG_CONN_URL
+    valueFrom:
+      secretKeyRef:
+        name: data-plane
+        key: _data-plane_postgres_connection_string


### PR DESCRIPTION
`PG_CONN_URL` is hard-coded in the `conductor` and `conductor-watcher` deployments. Remove hard-coded value to allow for overriding the environment variable.