### PR TITLE
bump controller version to latest

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.44.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff7726371b8cc751b4d743ba6843387e7d023b7bf06050ee1928f55b8c83f66"
+checksum = "93af300aca5d5bfc54b1c43a28984d5f21ff8d2b61bc6388ec3a2773a5250afc"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "controller",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.5.6"
+version = "0.5.7"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ schemars = {version = "0.8.12", features = ["chrono"]}
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false } # This version has to be in line with the same version we use in the controller
 serde = "1.0.152"
 serde_yaml = "0.9.21"
-tembo-controller = { package = "controller", version = "0.44.1" }
+tembo-controller = { package = "controller", version = "0.45.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }
 


### PR DESCRIPTION
Bumping controller version in hops of fixing a issue in the control-plane webserver

```
error[E0308]: mismatched types
   --> cp-webserver/src/types/coredb_cp.rs:472:34
    |
472 |             validate_app_storage(app_service)?;
    |             -------------------- ^^^^^^^^^^^ expected `controller::app_service::types::AppService`, found a different `controller::app_service::types::AppService`
    |             |
    |             arguments to this function are incorrect
    |
    = note: `controller::app_service::types::AppService` and `controller::app_service::types::AppService` have similar names, but are actually distinct types
note: `controller::app_service::types::AppService` is defined in crate `controller`
```