### PR TITLE
bump conductor to use latest controller version

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.44.1"
+version = "0.45.0"
 dependencies = [
  "actix-web",
  "anyhow",


### PR DESCRIPTION
Use correct controller version

fixes: [PLAT-430](https://linear.app/tembo/issue/PLAT-430/add-spot-option-in-control-plane-api)