### PR TITLE
add node_selector to appsvc and pooler deployments

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.45.0"
+version = "0.45.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -456,6 +456,7 @@ fn generate_deployment(
     }
 
     let affinity = placement.as_ref().and_then(|p| p.combine_affinity_items());
+    let node_selector = placement.as_ref().and_then(|p| p.node_selector.clone());
     let tolerations = placement.as_ref().map(|p| p.tolerations.clone());
     let topology_spread_constraints = placement
         .as_ref()
@@ -477,6 +478,7 @@ fn generate_deployment(
             volume_mounts: Some(volume_mounts),
             ..Container::default()
         }],
+        node_selector,
         tolerations,
         topology_spread_constraints,
         volumes: Some(volumes),
@@ -974,7 +976,7 @@ mod tests {
                 volumeSnapshot:
                   enabled: true
                   snapshotClass: "csi-vsc"
-              image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e 
+              image: quay.io/tembo/tembo-pg-cnpg:15.3.0-5-48d489e
               port: 5432
               replicas: 1
               resources:

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1270,13 +1270,14 @@ pub async fn reconcile_pooler(
     let namespace = cdb.namespace().unwrap();
     let owner_reference = cdb.controller_owner_ref(&()).unwrap();
     let pooler_api: Api<Pooler> = Api::namespaced(client.clone(), namespace.as_str());
-    let pooler_tolerations = placement
+    let tolerations = placement
         .as_ref()
         .and_then(|config| config.convert_pooler_tolerations());
     let topology_spread_constraints = placement
         .as_ref()
         .and_then(|p| p.convert_pooler_topology_spread_constraints());
     let affinity = placement.as_ref().and_then(|p| p.convert_pooler_affinity());
+    let node_selector = placement.as_ref().and_then(|p| p.node_selector.clone());
 
     // If pooler is enabled, create or update
     if cdb.spec.connectionPooler.enabled {
@@ -1312,7 +1313,8 @@ pub async fn reconcile_pooler(
                             ..Default::default()
                         }],
                         affinity,
-                        tolerations: pooler_tolerations,
+                        node_selector,
+                        tolerations,
                         topology_spread_constraints,
                         ..Default::default()
                     }),
@@ -1539,7 +1541,7 @@ fn cnpg_scheduled_backup(
     };
 
     // TODO: reenable this once we have a work around for snapshots
-    // Becasue the snapshot name can easily be over the character limit for k8s
+    // Because the snapshot name can easily be over the character limit for k8s
     // we will need to trim the name to 43 characters and append "-snap"
     // let snap_name = generate_scheduled_backup_snapshot_name(name);
 
@@ -1699,7 +1701,7 @@ pub async fn get_latest_generated_node(
     }
 }
 
-/// fenced_pods_initialized checks if fenced pods are initialized and retuns a bool or action in a
+/// fenced_pods_initialized checks if fenced pods are initialized and returns a bool or action in a
 /// result
 #[instrument(skip(cdb, ctx), fields(trace_id, instance_name = %cdb.name_any()))]
 async fn fenced_pods_initialized(


### PR DESCRIPTION
Small PR to add `nodeSelector` to the `Pooler` and AppSvc `Deployment` specs.  I missed adding this earlier.

