### PR TITLE
Don't use instance name or org name to determine namespace

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/aws/cloudformation.rs
+++ b/conductor/src/aws/cloudformation.rs
@@ -11,9 +11,8 @@ use std::sync::Arc;
 use crate::errors::ConductorError;
 
 pub struct CloudFormationParams {
-    pub backup_archive_bucket: String,
-    pub org_name: String,
-    pub db_name: String,
+    pub bucket_name: String,
+    pub org: String,
     pub iam_role_name: String,
     pub cf_template_bucket: String,
     pub namespace: String,
@@ -26,37 +25,14 @@ pub struct AWSConfigState {
 }
 
 impl CloudFormationParams {
-    pub fn new(
-        backup_archive_bucket: String,
-        org_name: String,
-        db_name: String,
-        iam_role_name: String,
-        cf_template_bucket: String,
-        namespace: String,
-        service_account_name: String,
-    ) -> Self {
-        Self {
-            backup_archive_bucket,
-            org_name,
-            db_name,
-            iam_role_name,
-            cf_template_bucket,
-            namespace,
-            service_account_name,
-        }
-    }
-
     pub fn validate(&self) -> Result<(), String> {
         if self.iam_role_name.is_empty() {
             return Err("IAM role name cannot be empty".to_string());
         }
-        if self.backup_archive_bucket.is_empty() {
+        if self.bucket_name.is_empty() {
             return Err("Cloudformation Bucket Name cannot be empty".to_string());
         }
-        if self.org_name.is_empty() {
-            return Err("Cloudformation Bucket Name cannot be empty".to_string());
-        }
-        if self.db_name.is_empty() {
+        if self.org.is_empty() {
             return Err("Cloudformation Bucket Name cannot be empty".to_string());
         }
         if self.cf_template_bucket.is_empty() {
@@ -111,11 +87,11 @@ impl AWSConfigState {
         let parameters = vec![
             Parameter::builder()
                 .parameter_key("BucketName")
-                .parameter_value(params.backup_archive_bucket.clone())
+                .parameter_value(params.bucket_name.clone())
                 .build(),
             Parameter::builder()
                 .parameter_key("BucketOrg")
-                .parameter_value(params.org_name.clone())
+                .parameter_value(params.org.clone())
                 .build(),
             Parameter::builder()
                 .parameter_key("RoleName")

--- a/conductor/src/types.rs
+++ b/conductor/src/types.rs
@@ -6,12 +6,11 @@ use controller::apis::coredb_types::{CoreDBSpec, CoreDBStatus};
 /// incoming message from control plane
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CRUDevent {
-    pub organization_name: String,
     pub data_plane_id: String,
+    pub namespace: String,
     pub org_id: String,
     pub inst_id: String,
     pub event_type: Event,
-    pub dbname: String,
     pub spec: Option<CoreDBSpec>,
 }
 

--- a/conductor/tests/integration_tests.rs
+++ b/conductor/tests/integration_tests.rs
@@ -83,13 +83,7 @@ mod test {
 
         // Configurations
         let mut rng = rand::thread_rng();
-        let org_name = "coredb-test-org-1234".to_owned();
-        // Use the max allowed org name length
-        assert_eq!(org_name.len(), 20);
-        let dbname = format!("test-coredb-{}", rng.gen_range(10000000..99999999));
-        // Use the max allowed instance name length
-        assert_eq!(dbname.len(), 20);
-        let namespace = format!("org-{}-inst-{}", org_name, dbname);
+        let namespace = format!("sample-{}", rng.gen_range(1000000..9999999));
 
         let limits: BTreeMap<String, String> = BTreeMap::from([
             ("cpu".to_owned(), "1".to_string()),
@@ -154,12 +148,11 @@ mod test {
         let mut spec: CoreDBSpec = serde_json::from_value(spec_js).unwrap();
 
         let msg = types::CRUDevent {
-            organization_name: org_name.clone(),
             data_plane_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             org_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             inst_id: "inst_02s4UKVbRy34SAYVSwZq2H".to_owned(),
             event_type: types::Event::Create,
-            dbname: dbname.clone(),
+            namespace: namespace.clone(),
             spec: Some(spec.clone()),
         };
 
@@ -252,12 +245,11 @@ mod test {
         let current_coredb = coredb_resource.clone();
         // println!("Updated spec: {:?}", spec.clone());
         let msg = types::CRUDevent {
-            organization_name: org_name.clone(),
             data_plane_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             org_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             inst_id: "inst_02s4UKVbRy34SAYVSwZq2H".to_owned(),
             event_type: types::Event::Update,
-            dbname: dbname.clone(),
+            namespace: namespace.clone(),
             spec: Some(spec.clone()),
         };
         let msg_id = queue.send(&myqueue, &msg).await;
@@ -323,12 +315,11 @@ mod test {
         // pod restarts correctly.
 
         let msg = types::CRUDevent {
-            organization_name: org_name.clone(),
             data_plane_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             org_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             inst_id: "inst_02s4UKVbRy34SAYVSwZq2H".to_owned(),
             event_type: types::Event::Restart,
-            dbname: dbname.clone(),
+            namespace: namespace.clone(),
             spec: Some(spec.clone()),
         };
         let msg_id = queue.send(&myqueue, &msg).await;
@@ -373,12 +364,11 @@ mod test {
 
         // delete the instance
         let msg = types::CRUDevent {
-            organization_name: org_name.clone(),
             data_plane_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             org_id: "org_02s3owPQskuGXHE8vYsGSY".to_owned(),
             inst_id: "inst_02s4UKVbRy34SAYVSwZq2H".to_owned(),
             event_type: types::Event::Delete,
-            dbname: dbname.clone(),
+            namespace: namespace.clone(),
             spec: None,
         };
         // println!("DELETE msg: {:?}", msg);
@@ -411,7 +401,7 @@ mod test {
         let aws_region = "us-east-1".to_owned();
         let region = Region::new(aws_region);
         let aws_config_state = AWSConfigState::new(region.clone()).await;
-        let stack_name = format!("org-{}-inst-{}-cf", org_name, dbname);
+        let stack_name = format!("{}-cf", namespace);
 
         // Check to see if the cloudformation stack exists
         let cf_stack_deleted = check_cf_stack_deletion(&aws_config_state, &stack_name).await;


### PR DESCRIPTION
Use the namespace field provided by control plane instead of using org name and instance name to determine what namespace to deploy into.