### PR TITLE
expose wal archiver timestamp

### DIFF
--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: 'Helm chart to deploy the tembo-operator'
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.5.1
+version: 0.5.2
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo

--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -2790,6 +2790,10 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              last_archiver_status:
+                format: date-time
+                nullable: true
+                type: string
               last_fully_reconciled_at:
                 format: date-time
                 nullable: true

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -739,6 +739,7 @@ pub struct CoreDBStatus {
     pub first_recoverability_time: Option<DateTime<Utc>>,
     pub pg_postmaster_start_time: Option<DateTime<Utc>>,
     pub last_fully_reconciled_at: Option<DateTime<Utc>>,
+    pub last_archiver_status: Option<DateTime<Utc>>,
 }
 
 #[cfg(test)]

--- a/tembo-operator/src/cloudnativepg/archive/mod.rs
+++ b/tembo-operator/src/cloudnativepg/archive/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod wal;

--- a/tembo-operator/src/cloudnativepg/archive/wal.rs
+++ b/tembo-operator/src/cloudnativepg/archive/wal.rs
@@ -1,0 +1,44 @@
+use crate::{
+    apis::coredb_types::CoreDB,
+    cloudnativepg::{clusters::ClusterStatusConditionsStatus, cnpg::get_cluster},
+    Context,
+};
+use chrono::{DateTime, Utc};
+use kube::{runtime::controller::Action, ResourceExt};
+use std::sync::Arc;
+use tracing::error;
+
+// Find status of the last time a WAL archive was successful and retrun the date
+pub async fn reconcile_last_archive_status(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+) -> Result<Option<DateTime<Utc>>, Action> {
+    let name = cdb.name_any();
+
+    let cluster = get_cluster(cdb, ctx.clone()).await;
+    match cluster {
+        Some(cluster) => {
+            if let Some(status) = &cluster.status {
+                if let Some(conditions) = &status.conditions {
+                    for condition in conditions {
+                        if condition.r#type == "ContinuousArchiving"
+                            && condition.status == ClusterStatusConditionsStatus::True
+                        {
+                            let last_transition_time = &condition.last_transition_time;
+                            if let Ok(last_transition_time) =
+                                DateTime::parse_from_rfc3339(last_transition_time)
+                            {
+                                return Ok(Some(last_transition_time.with_timezone(&Utc)));
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(None)
+        }
+        None => {
+            error!("Failed to get cluster: {}", &name);
+            Err(Action::requeue(tokio::time::Duration::from_secs(300)))
+        }
+    }
+}

--- a/tembo-operator/src/cloudnativepg/mod.rs
+++ b/tembo-operator/src/cloudnativepg/mod.rs
@@ -2,6 +2,7 @@ pub mod backups;
 pub mod clusters;
 pub(crate) mod cnpg;
 // pub(crate) mod cnpg_backups;
+pub(crate) mod archive;
 pub mod cnpg_utils;
 pub mod hibernate;
 pub(crate) mod placement;

--- a/tembo-operator/src/controller.rs
+++ b/tembo-operator/src/controller.rs
@@ -5,6 +5,7 @@ use crate::{
     apis::coredb_types::{CoreDB, CoreDBStatus, VolumeSnapshot},
     app_service::manager::reconcile_app_services,
     cloudnativepg::{
+        archive::wal::reconcile_last_archive_status,
         backups::Backup,
         cnpg::{
             cnpg_cluster_from_cdb, reconcile_cnpg, reconcile_cnpg_scheduled_backup,
@@ -376,6 +377,7 @@ impl CoreDB {
             reconcile_extensions(self, ctx.clone(), &coredbs, &name).await?;
 
         let recovery_time = self.get_recovery_time(ctx.clone()).await?;
+        let last_archiver_status = reconcile_last_archive_status(self, ctx.clone()).await?;
 
         let current_config_values = get_current_config_values(self, ctx.clone()).await?;
         let mut new_status = CoreDBStatus {
@@ -389,6 +391,7 @@ impl CoreDB {
             first_recoverability_time: recovery_time,
             pg_postmaster_start_time,
             last_fully_reconciled_at: None,
+            last_archiver_status,
         };
 
         let current_time = Utc::now();

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -505,7 +505,7 @@ async fn get_trunk_project_version(
         .is_ok();
         // If trunk project exists for this version, use it
         if trunk_project_version_exists {
-            trunk_project_version = location_to_toggle.version.clone();
+            trunk_project_version.clone_from(&location_to_toggle.version);
         }
         // Otherwise, fall back to latest version
         else {

--- a/tembo-operator/src/extensions/types.rs
+++ b/tembo-operator/src/extensions/types.rs
@@ -189,10 +189,7 @@ pub fn generate_extension_enable_cmd(
     }
     let mut command_suffix: String = "".to_string();
     if EXTRA_COMMANDS_TO_ENABLE_EXTENSION.contains_key(ext_name) {
-        command_suffix = EXTRA_COMMANDS_TO_ENABLE_EXTENSION
-            .get(ext_name)
-            .unwrap()
-            .clone();
+        command_suffix.clone_from(EXTRA_COMMANDS_TO_ENABLE_EXTENSION.get(ext_name).unwrap());
     }
     // only specify the schema if it provided
     let command = match ext_loc.enabled {


### PR DESCRIPTION
Expose the timestamp of the WAL archive from CNPG into `CoreDBStatus`.  This will allow us to better find a PITR timestamp and ensure that there is an archive when a user requests a specific time to restore to.

* includes some code cleanup clippy introduced in 1.78.0.

fixes: [PLAT-674](https://linear.app/tembo/issue/PLAT-674/find-work-around-for-restore-issue)