### PR TITLE
Replace Stacks ComputeTemplate with ComputeConstraint

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.45.1"
+version = "0.46.0"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -521,6 +521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "strum",
  "thiserror",
  "tokio",
  "tonic",
@@ -2419,6 +2420,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "syn"

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.45.1"
+version = "0.46.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"
@@ -53,6 +53,7 @@ anyhow = "1.0.72"
 rand = "0.8.5"
 reqwest = { version = "0.11.20", features = ["json", "trust-dns"] }
 utoipa = "3.5.0"
+strum = { version = "0.26.2", features = ["derive"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -15,7 +15,7 @@ use utoipa::ToSchema;
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub struct Stack {
     pub name: String,
-    pub compute_templates: Option<Vec<ComputeTemplate>>,
+    pub compute_constraints: Option<ComputeConstraint>,
     pub description: Option<String>,
     /// Organization hosting the Docker images used in this stack
     /// Default: "tembo"
@@ -94,19 +94,18 @@ fn default_storage() -> String {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, JsonSchema, PartialEq)]
-pub struct ComputeTemplate {
-    pub cpu: String,
-    pub memory: String,
-    pub instance_class: InstanceClass,
+pub struct ComputeConstraint {
+    pub min: Option<ComputeResource>,
+    pub max: Option<ComputeResource>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
-pub enum InstanceClass {
-    #[default]
-    GeneralPurpose,
-    MemoryOptimized,
-    ComputeOptimized,
+
+#[derive(Clone, Debug, Serialize, Deserialize, ToSchema, JsonSchema, PartialEq)]
+pub struct ComputeResource {
+    pub cpu: Option<String>,
+    pub memory: Option<String>,
 }
+
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub struct ImagePerPgVersion {

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -15,6 +15,7 @@ use utoipa::ToSchema;
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub struct Stack {
     pub name: String,
+    /// specifies any resource constraints that should be applied to an instance of the Stack
     pub compute_constraints: Option<ComputeConstraint>,
     pub description: Option<String>,
     /// Organization hosting the Docker images used in this stack
@@ -96,7 +97,6 @@ fn default_storage() -> String {
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, JsonSchema, PartialEq)]
 pub struct ComputeConstraint {
     pub min: Option<ComputeResource>,
-    pub max: Option<ComputeResource>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, JsonSchema, PartialEq)]

--- a/tembo-operator/src/stacks/types.rs
+++ b/tembo-operator/src/stacks/types.rs
@@ -99,13 +99,11 @@ pub struct ComputeConstraint {
     pub max: Option<ComputeResource>,
 }
 
-
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema, JsonSchema, PartialEq)]
 pub struct ComputeResource {
     pub cpu: Option<String>,
     pub memory: Option<String>,
 }
-
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, ToSchema)]
 pub struct ImagePerPgVersion {


### PR DESCRIPTION
Instead of specifying all possible CPU and Mem combinations, the Stack spec will just specify a constraint. for example, a minimum CPU and Memory amount.