### PR TITLE
Revert "Stack metrics"

### DIFF
--- a/tembo-operator/src/extensions/database_queries.rs
+++ b/tembo-operator/src/extensions/database_queries.rs
@@ -33,7 +33,7 @@ pub fn check_input(input: &str) -> bool {
 pub const LIST_SHARED_PRELOAD_LIBRARIES_QUERY: &str = r#"SHOW shared_preload_libraries;"#;
 
 pub const LIST_DATABASES_QUERY: &str =
-    r#"SELECT datname FROM pg_database WHERE datname != 'template0';"#;
+    r#"SELECT datname FROM pg_database WHERE datistemplate = false;"#;
 
 pub const LIST_EXTENSIONS_QUERY: &str = r#"select
 distinct on

--- a/tembo-stacks/src/stacks/specs/message_queue.yaml
+++ b/tembo-stacks/src/stacks/specs/message_queue.yaml
@@ -60,12 +60,6 @@ extensions:
       - database: postgres
         enabled: true
         version: 1.1.1
-      - database: app
-        enabled: true
-        version: 1.1.1
-      - database: template1
-        enabled: true
-        version: 1.1.1
   - name: pg_partman
     locations:
       - database: postgres
@@ -73,7 +67,7 @@ extensions:
         version: 4.7.4
 postgres_metrics:
   pgmq:
-      query: select queue_name, queue_length, oldest_msg_age_sec, newest_msg_age_sec, total_messages, current_database() as datname from pgmq.metrics_all()
+      query: select queue_name, queue_length, oldest_msg_age_sec, newest_msg_age_sec, total_messages from pgmq.metrics_all()
       master: true
       metrics:
         - queue_name:
@@ -91,11 +85,7 @@ postgres_metrics:
         - total_messages:
             usage: GAUGE
             description: Total number of messages that have passed into the queue.
-        - datname:
-            usage: "LABEL"
-            description: "Name of current database"
       target_databases:
-        - "*"
         - "postgres"
 postgres_config_engine: mq
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/vectordb.yaml
+++ b/tembo-stacks/src/stacks/specs/vectordb.yaml
@@ -88,12 +88,6 @@ extensions:
     - database: postgres
       enabled: true
       version: 0.15.0
-    - database: app
-      enabled: true
-      version: 0.15.0
-    - database: template1
-      enabled: true
-      version: 0.15.0
   - name: pg_stat_statements
     locations:
       - database: postgres
@@ -129,17 +123,3 @@ postgres_config:
     value: vectorize,pg_stat_statements,pg_cron
   - name: vectorize.embedding_service_url
     value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1/embeddings
-postgres_metrics:
-  vectorize_jobs:
-      query: select count(*) as total_jobs, current_database() as datname from vectorize.job
-      master: true
-      metrics:
-        - total_jobs:
-            usage: GAUGE
-            description: Number of vectorize jobs
-        - datname:
-            usage: "LABEL"
-            description: "Name of current database"
-      target_databases:
-        - "*"
-        - "postgres"

--- a/tembo-stacks/src/stacks/types.rs
+++ b/tembo-stacks/src/stacks/types.rs
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(mq_metrics.queries.len(), 1);
         assert!(mq_metrics.queries.contains_key("pgmq"));
         assert!(mq_metrics.queries["pgmq"].master);
-        assert_eq!(mq_metrics.queries["pgmq"].metrics.len(), 6);
+        assert_eq!(mq_metrics.queries["pgmq"].metrics.len(), 5);
 
         let mut std = get_stack(StackType::Standard);
         let infra = Infrastructure {


### PR DESCRIPTION
Reverts tembo-io/tembo#743

Many extensions need to have database specific config in order to be enabled, which prevents us from creating the extension in `template1`.