### PR TITLE
derive default on cdb spec

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.47.0"
+version = "0.47.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -373,8 +373,7 @@ pub struct PgBouncer {
 ///   name: test-db
 /// spec: {}
 /// ````
-#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, JsonSchema)]
-#[cfg_attr(test, derive(Default))]
+#[derive(CustomResource, Default, Deserialize, Serialize, Clone, Debug, JsonSchema)]
 #[kube(kind = "CoreDB", group = "coredb.io", version = "v1alpha1", namespaced)]
 #[kube(status = "CoreDBStatus", shortname = "cdb")]
 #[allow(non_snake_case)]


### PR DESCRIPTION
Always derive the Default trait so we can use it when importing the struct in other projects.