### PR TITLE
rework how we lookup the last WAL archive time

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.47.1"
+version = "0.47.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"
@@ -29,7 +29,10 @@ telemetry = ["tonic", "opentelemetry-otlp"]
 actix-web = "4.3.1"
 futures = "0.3.28"
 tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread"] }
-k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false }
+k8s-openapi = { version = "0.18.0", features = [
+  "v1_25",
+  "schemars",
+], default-features = false }
 schemars = { version = "0.8.12", features = ["chrono"] }
 serde = { version = "1.0.180", features = ["derive"] }
 serde_json = "1.0.104"
@@ -40,7 +43,9 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 tracing-opentelemetry = "0.19.0"
 opentelemetry = { version = "0.19.0", features = ["trace", "rt-tokio"] }
-opentelemetry-otlp = { version = "0.12.0", features = ["tokio"], optional = true }
+opentelemetry-otlp = { version = "0.12.0", features = [
+  "tokio",
+], optional = true }
 tonic = { version = "0.8.0", optional = true } # 0.9 blocked on opentelemetry-otlp release
 thiserror = "1.0.44"
 passwords = "3.1.13"

--- a/tembo-operator/src/cloudnativepg/archive/wal.rs
+++ b/tembo-operator/src/cloudnativepg/archive/wal.rs
@@ -1,44 +1,63 @@
-use crate::{
-    apis::coredb_types::CoreDB,
-    cloudnativepg::{clusters::ClusterStatusConditionsStatus, cnpg::get_cluster},
-    Context,
-};
+use crate::{apis::coredb_types::CoreDB, Context};
 use chrono::{DateTime, Utc};
-use kube::{runtime::controller::Action, ResourceExt};
+use kube::runtime::controller::Action;
 use std::sync::Arc;
-use tracing::error;
 
-// Find status of the last time a WAL archive was successful and retrun the date
+const WAL_ARCHIVE_STATUS_QUERY: &str = r#"
+SELECT
+    to_char((last_archived_time::timestamp), 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')
+FROM pg_stat_archiver;
+"#;
+
+// WalArchiveStatus struct to hold the status of the WAL archive
+// for now we are only interested in the last archived WAL time
+#[derive(Debug, Clone)]
+pub struct WalArchiveStatus {
+    pub last_archived_time: Option<DateTime<Utc>>,
+}
+
+/// get_wal_archive_status queries the pg_stat_archiver table to get the status of the WAL archive
+/// Returns a WalArchiveStatus struct
+pub async fn get_wal_archive_status(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+) -> Result<WalArchiveStatus, Action> {
+    let query = cdb
+        .psql(
+            WAL_ARCHIVE_STATUS_QUERY.to_string(),
+            "postgres".to_string(),
+            ctx.clone(),
+        )
+        .await?;
+
+    let last_archived_time = query.get_field(0).and_then(|s| parse_date_time(&s));
+
+    // Convert the query result into a WalArchiveStatus struct
+    let wal_archive_status = WalArchiveStatus { last_archived_time };
+
+    Ok(wal_archive_status)
+}
+
+/// Parses a date-time string in ISO 8601 format and converts it to a `DateTime<Utc>`.
+fn parse_date_time(date_str: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(date_str)
+        .map(|dt| dt.with_timezone(&Utc))
+        .ok()
+}
+
+// Find status of the last time a WAL archive was successful and return the date
 pub async fn reconcile_last_archive_status(
     cdb: &CoreDB,
     ctx: Arc<Context>,
 ) -> Result<Option<DateTime<Utc>>, Action> {
-    let name = cdb.name_any();
+    // Get the WAL archive status from the get_wal_archive_status function
+    let wal_archive_status = get_wal_archive_status(cdb, ctx.clone()).await?;
 
-    let cluster = get_cluster(cdb, ctx.clone()).await;
-    match cluster {
-        Some(cluster) => {
-            if let Some(status) = &cluster.status {
-                if let Some(conditions) = &status.conditions {
-                    for condition in conditions {
-                        if condition.r#type == "ContinuousArchiving"
-                            && condition.status == ClusterStatusConditionsStatus::True
-                        {
-                            let last_transition_time = &condition.last_transition_time;
-                            if let Ok(last_transition_time) =
-                                DateTime::parse_from_rfc3339(last_transition_time)
-                            {
-                                return Ok(Some(last_transition_time.with_timezone(&Utc)));
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(None)
-        }
-        None => {
-            error!("Failed to get cluster: {}", &name);
-            Err(Action::requeue(tokio::time::Duration::from_secs(300)))
-        }
+    // If the last archived WAL time is None, return None
+    if wal_archive_status.last_archived_time.is_none() {
+        return Ok(None);
     }
+
+    // If wal_archive_status.last_archived_time is Some, return the last archived time
+    Ok(wal_archive_status.last_archived_time)
 }

--- a/tembo-operator/src/psql.rs
+++ b/tembo-operator/src/psql.rs
@@ -22,6 +22,21 @@ impl PsqlOutput {
             success,
         }
     }
+
+    // Get a field from the stdout by index
+    pub fn get_field(&self, index: usize) -> Option<String> {
+        self.stdout.as_ref().and_then(|output| {
+            let lines: Vec<&str> = output.lines().collect();
+
+            lines.get(2).map(|line| {
+                line.split('|')
+                    .map(str::trim)
+                    .nth(index)
+                    .unwrap_or("")
+                    .to_string()
+            })
+        })
+    }
 }
 
 pub struct PsqlCommand {

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -4705,6 +4705,14 @@ CREATE EVENT TRIGGER pgrst_watch
         // Wait for backup to complete
         has_backup_completed(context.clone(), &namespace, &backup_name).await;
 
+        // Check to make sure CoreDBStatus has last_archiver_status set to a DateTime<Utc>
+        let cdbstatus = coredbs.get(name).await.unwrap();
+        let last_archiver_state = cdbstatus
+            .status
+            .as_ref()
+            .and_then(|stats| stats.last_archiver_status);
+        assert!(last_archiver_state.is_some());
+
         // If the backup is complete, we can now restore to a new instance in a new namespace
         let suffix = rng.gen_range(0..100000);
         let restore_name = &format!("test-coredb-restore-{}", suffix);
@@ -4882,6 +4890,14 @@ CREATE EVENT TRIGGER pgrst_watch
         )
         .await;
         assert!(result.stdout.clone().unwrap().contains("test"));
+
+        // Check to make sure CoreDBStatus has last_archiver_status set to a DateTime<Utc>
+        let cdbstatus = coredbs.get(name).await.unwrap();
+        let last_archiver_state = cdbstatus
+            .status
+            .as_ref()
+            .and_then(|stats| stats.last_archiver_status);
+        assert!(last_archiver_state.is_some());
 
         // CLEANUP TEST
         // Cleanup CoreDB


### PR DESCRIPTION
Rework the way we get the last time WAL was archived and set it in `CoreDBStatus.last_archiver_status`

fixes: [CLOUD-674](https://linear.app/tembo/issue/CLOUD-674/find-work-around-for-restore-issue)