### PR TITLE
Configurable `AWS_REGION` in conductor CloudFormation

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -447,7 +447,10 @@ pub struct StackOutputs {
     pub role_arn: Option<String>,
 }
 
-pub async fn lookup_role_arn(aws_region: String, namespace: &str) -> Result<String, ConductorError> {
+pub async fn lookup_role_arn(
+    aws_region: String,
+    namespace: &str,
+) -> Result<String, ConductorError> {
     let stack_outputs = get_stack_outputs(aws_region, namespace).await?;
     let role_arn = stack_outputs
         .role_arn

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -447,10 +447,7 @@ pub struct StackOutputs {
     pub role_arn: Option<String>,
 }
 
-pub async fn lookup_role_arn(
-    aws_region: String,
-    namespace: &str,
-) -> Result<String, ConductorError> {
+pub async fn lookup_role_arn(aws_region: String, namespace: &str) -> Result<String, ConductorError> {
     let stack_outputs = get_stack_outputs(aws_region, namespace).await?;
     let role_arn = stack_outputs
         .role_arn


### PR DESCRIPTION
While configuring backups with a Tembo Self Hosted customer, we ran into an issue due to `us-east-1` hard-coded in conductor's cloud formation logic. This makes the value configurable and defaults to `us-east-1` if not set.