### PR TITLE
Release timeseries 0.1.5, correct cron.host

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/timeseries.yaml
+++ b/tembo-stacks/src/stacks/specs/timeseries.yaml
@@ -9,6 +9,8 @@ images:
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:
+  - name: cron.host
+    value: /controller/run
   - name: autovacuum_vacuum_scale_factor
     value: 0.05
   - name: autovacuum_vacuum_insert_scale_factor
@@ -27,7 +29,7 @@ postgres_config:
     value: logical
 trunk_installs:
   - name: pg_timeseries
-    version: 0.1.4
+    version: 0.1.5
   - name: hydra_columnar
     version: 1.1.1
   - name: pg_cron
@@ -41,7 +43,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.1.4
+        version: 0.1.5
   - name: pg_stat_statements
     locations:
       - database: postgres


### PR DESCRIPTION
Needed to bump the version again to fix a problem with the cron job itself (related to the schema for partman in cloud). Other than that, just the YAML change for the host and a version bump in the toml.