### PR TITLE
Add explicit cron.database_name

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/timeseries.yaml
+++ b/tembo-stacks/src/stacks/specs/timeseries.yaml
@@ -9,6 +9,8 @@ images:
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:
+  - name: cron.database_name
+    value: postgres
   - name: cron.host
     value: /controller/run
   - name: autovacuum_vacuum_scale_factor


### PR DESCRIPTION
This error only started showing up once I specified cron.host, so it might be the case I need to specify database_name too. Threads online about this issue are unclear, but this seems related.