### PR TITLE
add probes to inference gateway

### DIFF
--- a/inference-gateway/Cargo.lock
+++ b/inference-gateway/Cargo.lock
@@ -835,6 +835,8 @@ name = "gateway"
 version = "0.1.0"
 dependencies = [
  "actix-cors",
+ "actix-http",
+ "actix-service",
  "actix-web",
  "env_logger",
  "log",

--- a/inference-gateway/Cargo.toml
+++ b/inference-gateway/Cargo.toml
@@ -15,3 +15,7 @@ serde_json = "1.0.117"
 sqlx = { version = "0.7.4",  features = [ "runtime-tokio-native-tls", "postgres", "chrono", "json"] }
 thiserror = "1.0.60"
 url = "2.5.0"
+
+[dev-dependencies]
+actix-http = "3.6.0"
+actix-service = "2.0.2"

--- a/inference-gateway/Makefile
+++ b/inference-gateway/Makefile
@@ -6,3 +6,6 @@ run:
 
 run-migrations:
 	sqlx migrate run
+
+test:
+	cargo test -- --ignored

--- a/inference-gateway/src/lib.rs
+++ b/inference-gateway/src/lib.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod db;
 pub mod errors;
 pub mod routes;
+pub mod server;

--- a/inference-gateway/src/main.rs
+++ b/inference-gateway/src/main.rs
@@ -2,7 +2,7 @@ use actix_cors::Cors;
 use actix_web::{middleware, web, App, HttpServer};
 use std::time::Duration;
 
-use gateway::{config, db, routes};
+use gateway::{config, db};
 
 use sqlx::{Pool, Postgres};
 
@@ -20,6 +20,8 @@ async fn main() {
         .await
         .expect("Failed to run migrations");
 
+    println!("Starting server on port {}", server_port);
+
     let reqwest_client: reqwest::Client = reqwest::Client::new();
     let _ = HttpServer::new(move || {
         let cors = Cors::permissive();
@@ -30,7 +32,7 @@ async fn main() {
             .app_data(web::Data::new(cfg.clone()))
             .app_data(web::Data::new(reqwest_client.clone()))
             .app_data(web::Data::new(dbclient.clone()))
-            .default_service(web::to(routes::forward::forward_request))
+            .configure(gateway::server::webserver_routes)
     })
     .workers(8)
     .keep_alive(Duration::from_secs(75))

--- a/inference-gateway/src/main.rs
+++ b/inference-gateway/src/main.rs
@@ -20,8 +20,6 @@ async fn main() {
         .await
         .expect("Failed to run migrations");
 
-    println!("Starting server on port {}", server_port);
-
     let reqwest_client: reqwest::Client = reqwest::Client::new();
     let _ = HttpServer::new(move || {
         let cors = Cors::permissive();

--- a/inference-gateway/src/routes/health.rs
+++ b/inference-gateway/src/routes/health.rs
@@ -1,0 +1,11 @@
+use actix_web::{get, HttpResponse, Responder};
+
+#[get("/ready")]
+async fn ready() -> impl Responder {
+    HttpResponse::Ok().json("ready")
+}
+
+#[get("/lively")]
+async fn lively() -> impl Responder {
+    HttpResponse::Ok().json("alive")
+}

--- a/inference-gateway/src/routes/mod.rs
+++ b/inference-gateway/src/routes/mod.rs
@@ -1,1 +1,2 @@
 pub mod forward;
+pub mod health;

--- a/inference-gateway/src/server.rs
+++ b/inference-gateway/src/server.rs
@@ -1,0 +1,10 @@
+use actix_web::web;
+
+use crate::routes;
+
+pub fn webserver_routes(configuration: &mut web::ServiceConfig) {
+    configuration
+        .service(routes::health::ready)
+        .service(routes::health::lively)
+        .default_service(web::to(routes::forward::forward_request));
+}

--- a/inference-gateway/tests/integration_test.rs
+++ b/inference-gateway/tests/integration_test.rs
@@ -3,6 +3,7 @@ mod util;
 use actix_web::test;
 use util::common;
 
+#[ignore]
 #[actix_web::test]
 async fn test_probes() {
     let app = common::get_test_app().await;

--- a/inference-gateway/tests/integration_test.rs
+++ b/inference-gateway/tests/integration_test.rs
@@ -1,0 +1,21 @@
+mod util;
+
+use actix_web::test;
+use util::common;
+
+#[actix_web::test]
+async fn test_probes() {
+    let app = common::get_test_app().await;
+
+    let req = test::TestRequest::get().uri("/ready").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let req = test::TestRequest::get().uri("/lively").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let req = test::TestRequest::get().uri("/notapath").to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_client_error());
+}

--- a/inference-gateway/tests/util.rs
+++ b/inference-gateway/tests/util.rs
@@ -1,0 +1,28 @@
+pub mod common {
+    use actix_http::Request;
+    use actix_service::Service;
+    use actix_web::test;
+    use actix_web::{dev::ServiceResponse, web, App, Error};
+    use sqlx::{Pool, Postgres};
+
+    #[cfg(test)]
+    pub async fn get_test_app() -> impl Service<Request, Response = ServiceResponse, Error = Error>
+    {
+        let config = gateway::config::Config::new().await;
+        let dbclient: Pool<Postgres> = gateway::db::connect(&config.pg_conn_str, 4)
+            .await
+            .expect("Failed to connect to database");
+        let reqwest_client: reqwest::Client = reqwest::Client::new();
+
+        sqlx::migrate!("./migrations");
+
+        test::init_service(
+            App::new()
+                .app_data(web::Data::new(config.clone()))
+                .app_data(web::Data::new(reqwest_client.clone()))
+                .app_data(web::Data::new(dbclient.clone()))
+                .configure(gateway::server::webserver_routes),
+        )
+        .await
+    }
+}


### PR DESCRIPTION
- adds ready and lively endpoints for probes, and a test
- small refactor to route config to make test setup easier and more consistent