### PR TITLE
run embedding app as user:nobody

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.8.11"
+version = "0.8.12"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/apps/embeddings.yaml
+++ b/tembo-stacks/src/apps/embeddings.yaml
@@ -1,6 +1,6 @@
 name: !embeddings
 appServices:
-  - image: quay.io/tembo/vector-serve:7343bf4
+  - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
     routing:
       - port: 3000

--- a/tembo-stacks/src/stacks/specs/rag.yaml
+++ b/tembo-stacks/src/stacks/specs/rag.yaml
@@ -8,7 +8,7 @@ images:
   16: "standard-cnpg:16-389a437"
 stack_version: 0.1.0
 appServices:
-  - image: quay.io/tembo/vector-serve:7343bf4
+  - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
     env:
       - name: TMPDIR

--- a/tembo-stacks/src/stacks/specs/vectordb.yaml
+++ b/tembo-stacks/src/stacks/specs/vectordb.yaml
@@ -8,7 +8,7 @@ images:
   16: "standard-cnpg:16-389a437"
 stack_version: 0.1.0
 appServices:
-  - image: quay.io/tembo/vector-serve:7343bf4
+  - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
     env:
       - name: TMPDIR


### PR DESCRIPTION
New container image allows the embedding container to run as `user:nobody`