### PR TITLE
update stack spec with metrics

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -512,9 +512,9 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "controller"
-version = "0.47.1"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb5e5bce112ef05f35c1dcfaf7fe34339d9392dc8aec3eda89495db1fe9078c"
+checksum = "ff3f80f9863877bef10bf8d6eb13ecad4bd01ccb0a15350ee3d2ab5604d7cc4d"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.114"
 serde_yaml = "0.9.21"
 strum = "0.26.2"
 strum_macros = "0.26.2"
-tembo-controller = { package = "controller", version = "0.47.1" }
+tembo-controller = { package = "controller", version = "0.48.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }
 

--- a/tembo-stacks/src/apps/app.rs
+++ b/tembo-stacks/src/apps/app.rs
@@ -347,7 +347,6 @@ mod tests {
     use tembo_controller::app_service::types::EnvVar;
     #[test]
     fn test_merge_app_reqs() {
-        //
         let app_config = AppConfig {
             env: Some(vec![
                 EnvVar {
@@ -396,6 +395,11 @@ mod tests {
             }
         }
         assert_eq!(to_find, 0);
+
+        // validate metrics end up in final_app
+        let metrics = app.metrics.expect("metrics not found");
+        assert_eq!(metrics.path, "/metrics".to_string());
+        assert_eq!(metrics.port, 3000);
     }
 
     #[test]

--- a/tembo-stacks/src/apps/embeddings.yaml
+++ b/tembo-stacks/src/apps/embeddings.yaml
@@ -2,6 +2,9 @@ name: !embeddings
 appServices:
   - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
+    metrics:
+      path: /metrics
+      port: 3000
     routing:
       - port: 3000
         ingressPath: /embeddings

--- a/tembo-stacks/src/stacks/specs/rag.yaml
+++ b/tembo-stacks/src/stacks/specs/rag.yaml
@@ -10,6 +10,9 @@ stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
+    metrics:
+      path: /metrics
+      port: 3000
     env:
       - name: TMPDIR
         value: /models

--- a/tembo-stacks/src/stacks/specs/vectordb.yaml
+++ b/tembo-stacks/src/stacks/specs/vectordb.yaml
@@ -10,6 +10,9 @@ stack_version: 0.1.0
 appServices:
   - image: quay.io/tembo/vector-serve:d5e7b63
     name: embeddings
+    metrics:
+      path: /metrics
+      port: 3000
     env:
       - name: TMPDIR
         value: /models

--- a/tembo-stacks/src/stacks/types.rs
+++ b/tembo-stacks/src/stacks/types.rs
@@ -362,4 +362,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_app_metrics() {
+        let vdb = get_stack(StackType::VectorDB);
+
+        let embedding_app = vdb
+            .app_services
+            .unwrap()
+            .into_iter()
+            .find(|app| app.name == "embeddings".to_string())
+            .expect("missing embedding app");
+
+        let metrics = embedding_app.metrics.expect("missing metrics");
+        assert_eq!(metrics.path, "/metrics");
+        assert_eq!(metrics.port, 3000);
+    }
 }


### PR DESCRIPTION
adds metrics configuration to the Stack spec (by pulling in latest `controller` crate) and to the embeddings apps