### PR TITLE
release stacks v0.9.0

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.8.13"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.8.13"
+version = "0.9.0"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
pulls in `metrics` to the Stacks.appServices spec