### PR TITLE
Fix pod monitor template

### DIFF
--- a/charts/tembo-operator/Chart.yaml
+++ b/charts/tembo-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: tembo-operator
 description: "Helm chart to deploy the tembo-operator"
 type: application
 icon: https://cloud.tembo.io/images/TemboElephant.png
-version: 0.6.2
+version: 0.6.3
 home: https://tembo.io
 sources:
   - https://github.com/tembo-io/tembo

--- a/charts/tembo-operator/templates/pod-monitor-operator.yaml
+++ b/charts/tembo-operator/templates/pod-monitor-operator.yaml
@@ -9,8 +9,8 @@ metadata:
   namespace: {{ $namespace }}
 spec:
   podMetricsEndpoints:
-  - path: {{ (index .Values "controller").podMonitor.path }}
-    port: {{ (index .Values "controller").podMonitor.port }}
+  - path: {{ (index .Values "controller").monitoring.podMonitor.path }}
+    port: {{ (index .Values "controller").monitoring.podMonitor.port }}
   namespaceSelector:
     matchNames:
       - {{ $namespace }}


### PR DESCRIPTION
Fix issue with pod monitor template in tembo operator chart:
`
Error: UPGRADE FAILED: template: tembo/charts/tembo/charts/tembo-operator/templates/pod-monitor-operator.yaml:12:28: executing "tembo/charts/tembo/charts/tembo-operator/templates/pod-monitor-operator.yaml" at <"controller">: nil pointer evaluating interface {}.path
`