### PR TITLE
tembo-stacks: fix parsing storages in tebibytes

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2419,7 +2419,6 @@ dependencies = [
  "futures",
  "k8s-openapi",
  "lazy_static",
- "regex",
  "schemars",
  "serde",
  "serde_json",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"
@@ -20,7 +20,6 @@ clap = { version = "4.5.4", features = ["derive"] }
 futures = "0.3.28"
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false } # This version has to be in line with the same version we use in the controller
 lazy_static = "1.4.0"
-regex = "1.10.4"
 schemars = {version = "0.8.12", features = ["chrono"]}
 serde = "1.0.152"
 serde_json = "1.0.114"


### PR DESCRIPTION
* Fixes parsing `storage` decls that can now be `1Ti`, `1.5Ti` and `2Ti`
* Removes a couple of heap allocations in the process
* Removes the `regex` dependency, which could perhaps save us a bit of build time, uses a simpler naive alternative instead