### PR TITLE
inference-gateway validation

### DIFF
--- a/inference-gateway/.sqlx/query-16e4a8024f80fd49f88246b8f18312b46d3541362f11a2f51193f5233c19e022.json
+++ b/inference-gateway/.sqlx/query-16e4a8024f80fd49f88246b8f18312b46d3541362f11a2f51193f5233c19e022.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT org_id, valid FROM inference.org_validation",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "org_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "valid",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "16e4a8024f80fd49f88246b8f18312b46d3541362f11a2f51193f5233c19e022"
+}

--- a/inference-gateway/Cargo.lock
+++ b/inference-gateway/Cargo.lock
@@ -98,10 +98,11 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -317,6 +318,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "atoi"
@@ -836,8 +843,10 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-http",
+ "actix-rt",
  "actix-service",
  "actix-web",
+ "anyhow",
  "env_logger",
  "log",
  "rand",
@@ -846,6 +855,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
+ "tokio",
  "url",
 ]
 
@@ -941,6 +951,12 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1387,6 +1403,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2312,11 +2338,24 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/inference-gateway/Cargo.toml
+++ b/inference-gateway/Cargo.toml
@@ -6,7 +6,9 @@ publish = false
 
 [dependencies]
 actix-cors = "0.7.0"
+actix-rt = "2.10.0"
 actix-web = "4.5.1"
+anyhow = "1.0.86"
 env_logger = "0.11.3"
 log = "0.4.21"
 reqwest = { version = "0.12.4", features = ["json"] }
@@ -14,6 +16,7 @@ serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
 sqlx = { version = "0.7.4",  features = [ "runtime-tokio-native-tls", "postgres", "chrono", "json"] }
 thiserror = "1.0.60"
+tokio = { version = "1", features = ["full"] }
 url = "2.5.0"
 
 [dev-dependencies]

--- a/inference-gateway/Makefile
+++ b/inference-gateway/Makefile
@@ -29,6 +29,6 @@ unit-test:
 	cargo test
 
 integration-test: run-mock-server
-	RUST_LOG=${RUST_LOG} LLM_SERVICE_HOST_PORT=${LLM_SERVICE_HOST_PORT} cargo test -- --ignored
+	RUST_LOG=${RUST_LOG} LLM_SERVICE_HOST_PORT=${LLM_SERVICE_HOST_PORT} cargo test ${TEST_NAME} -- --ignored --nocapture
 
 test-all: unit-test integration-test

--- a/inference-gateway/README.md
+++ b/inference-gateway/README.md
@@ -8,7 +8,6 @@ This is a LLM hosting service for the Tembo Platform. It is built on top of [vLL
 - `Inference Server`: a vLLM model server that hosts various LLMs
 - `Postgres`: a standard Postgres database
 
-
 ```mermaid
 graph LR
 A[Gateway] --> |forward request| B[Inference Server]

--- a/inference-gateway/docker-compose.yml
+++ b/inference-gateway/docker-compose.yml
@@ -1,7 +1,9 @@
 services:
   postgres:
     restart: always
-    image: quay.io/tembo/timeseries-pg:latest
+    build:
+      dockerfile: docker/Dockerfile.postgres
+      context: .
     ports:
       - 5432:5432
     environment:

--- a/inference-gateway/docker/Dockerfile.postgres
+++ b/inference-gateway/docker/Dockerfile.postgres
@@ -1,0 +1,12 @@
+FROM quay.io/tembo/tembo-local
+
+RUN trunk install pg_timeseries
+RUN trunk install pg_cron
+RUN trunk install pg_partman
+RUN trunk install postgres_fdw
+
+USER root
+
+RUN echo "shared_preload_libraries = 'pg_cron'" >> $PGDATA/postgresql.conf
+
+USER postgres

--- a/inference-gateway/migrations/20240625184124_org_validation.sql
+++ b/inference-gateway/migrations/20240625184124_org_validation.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS inference.org_validation (
+    org_id TEXT UNIQUE NOT NULL,
+    valid bool not null default false,
+    last_updated_at timestamp with time zone not null default now()
+);
+
+CREATE INDEX ON inference.org_validation (org_id);

--- a/inference-gateway/migrations/20240626175841_fdw.sql
+++ b/inference-gateway/migrations/20240626175841_fdw.sql
@@ -1,0 +1,29 @@
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+CREATE SERVER IF NOT EXISTS foreign_validation_server
+FOREIGN DATA WRAPPER postgres_fdw
+OPTIONS (host 'localhost', port '5432', dbname 'postgres');
+
+CREATE USER MAPPING IF NOT EXISTS FOR postgres
+SERVER foreign_validation_server
+OPTIONS (user 'postgres', password 'postgres');
+
+CREATE FOREIGN TABLE IF NOT EXISTS fdw_paid_organizations (
+    organization_id text NOT NULL,
+    has_cc boolean not null default false
+)
+SERVER foreign_validation_server
+OPTIONS (schema_name 'public', table_name 'paid_organizations');
+
+SELECT cron.schedule('refresh-validations', '1 second', $$
+    INSERT INTO inference.org_validation
+    SELECT 
+        organization_id as org_id,
+        has_cc as valid,
+        now() as last_updated_at
+    FROM fdw_paid_organizations
+    ON CONFLICT (org_id, valid) DO UPDATE SET
+        valid = EXCLUDED.valid,
+        last_updated_at = EXCLUDED.last_updated_at
+$$);

--- a/inference-gateway/src/config.rs
+++ b/inference-gateway/src/config.rs
@@ -7,6 +7,8 @@ pub struct Config {
     pub llm_service_host_port: Url,
     pub pg_conn_str: String,
     pub server_port: u16,
+    pub org_validation_enabled: bool,
+    pub org_validation_cache_refresh_interval_sec: u64,
 }
 
 impl Config {
@@ -20,6 +22,15 @@ impl Config {
             server_port: from_env_default("WEBSERVER_PORT", "8080")
                 .parse::<u16>()
                 .unwrap_or(8080),
+            org_validation_enabled: from_env_default("ORG_VALIDATION_ENABLED", "true")
+                .parse()
+                .expect("ORG_VALIDATION_ENABLED must be a boolean"),
+            org_validation_cache_refresh_interval_sec: from_env_default(
+                "ORG_VALIDATION_CACHE_REFRESH_INTERVAL_SEC",
+                "10",
+            )
+            .parse()
+            .expect("ORG_VALIDATION_CACHE_REFRESH_INTERVAL_SEC must be an integer"),
         }
     }
 }

--- a/inference-gateway/src/lib.rs
+++ b/inference-gateway/src/lib.rs
@@ -3,3 +3,4 @@ pub mod db;
 pub mod errors;
 pub mod routes;
 pub mod server;
+pub mod validation;

--- a/inference-gateway/src/main.rs
+++ b/inference-gateway/src/main.rs
@@ -2,34 +2,22 @@ use actix_cors::Cors;
 use actix_web::{middleware, web, App, HttpServer};
 use std::time::Duration;
 
-use gateway::{config, db};
-
-use sqlx::{Pool, Postgres};
-
 #[actix_web::main]
 async fn main() {
     env_logger::init();
 
-    let cfg = config::Config::new().await;
-    let server_port = cfg.server_port;
-    let dbclient: Pool<Postgres> = db::connect(&cfg.pg_conn_str, 4)
-        .await
-        .expect("Failed to connect to database");
-    sqlx::migrate!("./migrations")
-        .run(&dbclient)
-        .await
-        .expect("Failed to run migrations");
-
-    let reqwest_client: reqwest::Client = reqwest::Client::new();
+    let startup_configs = gateway::server::webserver_startup_config().await;
+    let server_port = startup_configs.cfg.server_port;
     let _ = HttpServer::new(move || {
         let cors = Cors::permissive();
 
         App::new()
             .wrap(cors)
             .wrap(middleware::Logger::default())
-            .app_data(web::Data::new(cfg.clone()))
-            .app_data(web::Data::new(reqwest_client.clone()))
-            .app_data(web::Data::new(dbclient.clone()))
+            .app_data(web::Data::new(startup_configs.cfg.clone()))
+            .app_data(web::Data::new(startup_configs.http_client.clone()))
+            .app_data(web::Data::new(startup_configs.pool.clone()))
+            .app_data(web::Data::new(startup_configs.validation_cache.clone()))
             .configure(gateway::server::webserver_routes)
     })
     .workers(8)

--- a/inference-gateway/src/server.rs
+++ b/inference-gateway/src/server.rs
@@ -1,10 +1,65 @@
 use actix_web::web;
 
 use crate::routes;
+use crate::{config, db, validation};
+
+use sqlx::{Pool, Postgres};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
 
 pub fn webserver_routes(configuration: &mut web::ServiceConfig) {
     configuration
         .service(routes::health::ready)
         .service(routes::health::lively)
         .default_service(web::to(routes::forward::forward_request));
+}
+
+#[derive(Debug, Clone)]
+pub struct ServerStartUpConfig {
+    pub cfg: config::Config,
+    pub pool: Arc<Pool<Postgres>>,
+    pub validation_cache: Arc<RwLock<HashMap<String, bool>>>,
+    pub http_client: reqwest::Client,
+}
+
+pub async fn webserver_startup_config() -> ServerStartUpConfig {
+    let cfg = config::Config::new().await;
+    let dbclient: Pool<Postgres> = db::connect(&cfg.pg_conn_str, 4)
+        .await
+        .expect("Failed to connect to database");
+    sqlx::migrate!("./migrations")
+        .run(&dbclient)
+        .await
+        .expect("Failed to run migrations");
+    let pool = Arc::new(dbclient);
+    let http_client: reqwest::Client = reqwest::Client::new();
+    let validation_cache = Arc::new(RwLock::new(HashMap::<String, bool>::new()));
+
+    if cfg.org_validation_enabled {
+        let cache_refresher = validation_cache.clone();
+        let pool_for_bg_task = pool.clone();
+        actix_rt::spawn(async move {
+            loop {
+                match validation::refresh_cache(&pool_for_bg_task, &cache_refresher).await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::error!("Failed to refresh cache: {:?}", e);
+                    }
+                }
+                tokio::time::sleep(Duration::from_secs(
+                    cfg.org_validation_cache_refresh_interval_sec,
+                ))
+                .await;
+            }
+        });
+    }
+
+    ServerStartUpConfig {
+        cfg,
+        pool,
+        validation_cache,
+        http_client,
+    }
 }

--- a/inference-gateway/src/validation.rs
+++ b/inference-gateway/src/validation.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use sqlx::postgres::PgPool;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub async fn refresh_cache(
+    pool: &PgPool,
+    cache: &Arc<RwLock<HashMap<String, bool>>>,
+) -> Result<(), sqlx::Error> {
+    let mut new_cache = HashMap::new();
+    let rows = sqlx::query!("SELECT org_id, valid FROM inference.org_validation")
+        .fetch_all(pool)
+        .await?;
+
+    log::debug!("Refreshing cache with {} rows", rows.len());
+    for row in rows {
+        new_cache.insert(row.org_id, row.valid);
+    }
+
+    let mut cache_write = cache.write().await;
+    *cache_write = new_cache;
+
+    Ok(())
+}
+
+/// checks if org's is flagged as validated
+pub async fn validate_org(org_id: &str, cache: &Arc<RwLock<HashMap<String, bool>>>) -> bool {
+    let cache_read = cache.read().await;
+    match cache_read.get(org_id) {
+        Some(valid) => *valid,
+        None => false,
+    }
+}

--- a/inference-gateway/tests/util.rs
+++ b/inference-gateway/tests/util.rs
@@ -3,24 +3,18 @@ pub mod common {
     use actix_service::Service;
     use actix_web::test;
     use actix_web::{dev::ServiceResponse, web, App, Error};
-    use sqlx::{Pool, Postgres};
 
     #[cfg(test)]
     pub async fn get_test_app() -> impl Service<Request, Response = ServiceResponse, Error = Error>
     {
-        let config = gateway::config::Config::new().await;
-        let dbclient: Pool<Postgres> = gateway::db::connect(&config.pg_conn_str, 4)
-            .await
-            .expect("Failed to connect to database");
-        let reqwest_client: reqwest::Client = reqwest::Client::new();
-
-        sqlx::migrate!("./migrations");
+        let startup_config = gateway::server::webserver_startup_config().await;
 
         test::init_service(
             App::new()
-                .app_data(web::Data::new(config.clone()))
-                .app_data(web::Data::new(reqwest_client.clone()))
-                .app_data(web::Data::new(dbclient.clone()))
+                .app_data(web::Data::new(startup_config.cfg.clone()))
+                .app_data(web::Data::new(startup_config.http_client.clone()))
+                .app_data(web::Data::new(startup_config.pool.clone()))
+                .app_data(web::Data::new(startup_config.validation_cache.clone()))
                 .configure(gateway::server::webserver_routes),
         )
         .await


### PR DESCRIPTION
- refactor of some of the webserver startup logic so that testing can be more consistent with how webserver actually runs
- in-memory cache of the validation table. see `test_validation` for an example of the behavior
- pg_cron refresh of validation table based on a fdw