### PR TITLE
Remove env variable since it's set in ArgoCD

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/conductor/templates/metrics-deployment.yaml
+++ b/charts/conductor/templates/metrics-deployment.yaml
@@ -45,8 +45,6 @@ spec:
             value: "false"
           - name: METRICS_REPORTER_ENABLED
             value: "true"
-          - name: METRICS_EVENTS_QUEUE
-            value: metrics_events
           - name: RUST_LOG
             value: {{ .Values.logLevel }}
           {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 10 }}{{- end }}


### PR DESCRIPTION
Remove `METRICS_QUEUE` as it's set in the ArgoCD deployment manifest