### PR TITLE
Ensure OLAP config has enough workers for pg_cron

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2411,7 +2411,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/config_engines.rs
+++ b/tembo-stacks/src/stacks/config_engines.rs
@@ -535,7 +535,7 @@ mod tests {
         assert_eq!(configs[5].name, "max_wal_size");
         assert_eq!(configs[5].value.to_string(), "2GB");
         assert_eq!(configs[6].name, "max_worker_processes");
-        assert_eq!(configs[6].value.to_string(), "4");
+        assert_eq!(configs[6].value.to_string(), "5");
         assert_eq!(configs[7].name, "shared_buffers");
         assert_eq!(configs[7].value.to_string(), "4096MB");
         assert_eq!(configs[8].name, "work_mem");
@@ -568,7 +568,7 @@ mod tests {
         assert_eq!(configs[5].name, "max_wal_size");
         assert_eq!(configs[5].value.to_string(), "2GB");
         assert_eq!(configs[6].name, "max_worker_processes");
-        assert_eq!(configs[6].value.to_string(), "1");
+        assert_eq!(configs[6].value.to_string(), "2");
         assert_eq!(configs[7].name, "shared_buffers");
         assert_eq!(configs[7].value.to_string(), "2048MB");
         assert_eq!(configs[8].name, "work_mem");

--- a/tembo-stacks/src/stacks/config_engines.rs
+++ b/tembo-stacks/src/stacks/config_engines.rs
@@ -168,7 +168,7 @@ fn olap_max_parallel_workers(cpu: f32) -> i32 {
 }
 
 fn olap_max_worker_processes(cpu: f32) -> i32 {
-    i32::max(1, cpu.round() as i32)
+    i32::max(1, cpu.round() as i32) + 1 // add one for cron
 }
 
 // olap formula for maintenance_work_mem


### PR DESCRIPTION
At the moment there's an extra bgw getting created (due to trunk modifying shared_preload_libraries), and this interaction prevents cron jobs from ever running on instances with small core counts (i.e. ones where this function returns 1).

This ensures there will be an extra worker for cron no matter what.