### PR TITLE
make metrics queue a partitioned queue

### DIFF
--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -86,7 +86,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
         .create_partitioned(&control_plane_events_queue)
         .await?;
     queue.create_partitioned(&data_plane_events_queue).await?;
-    queue.create(&metrics_events_queue).await?;
+    queue.create_partitioned(&metrics_events_queue).await?;
 
     // Infer the runtime environment and try to create a Kubernetes Client
     let client = Client::try_default().await?;


### PR DESCRIPTION
When creating the metrics queue, make sure it's partitioned.