### PR TITLE
Configurable service account name

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/conductor/templates/deployment.yaml
+++ b/charts/conductor/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "conductor.fullname" . }}
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/conductor/templates/metrics-deployment.yaml
+++ b/charts/conductor/templates/metrics-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "conductor.fullname" . }}
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/conductor/templates/serviceaccount.yaml
+++ b/charts/conductor/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "conductor.fullname" . }}
+  name: {{ include "conductor.serviceAccountName" . }}
   labels:
     {{- include "conductor.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/conductor/templates/watcher-deployment.yaml
+++ b/charts/conductor/templates/watcher-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "conductor.fullname" . }}
+      serviceAccountName: {{ include "conductor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:


### PR DESCRIPTION
```
➜  conductor git:(conductor-sa-name) helm template --set serviceAccount.name='foobar' . | grep -A5 'kind: ServiceA'
kind: ServiceAccount
metadata:
  name: foobar
  labels:
    helm.sh/chart: conductor-0.5.1
    app.kubernetes.io/name: conductor
```


```
➜  conductor git:(conductor-sa-name) helm template . | grep -A5 'kind: ServiceA'
kind: ServiceAccount
metadata:
  name: default
  labels:
    helm.sh/chart: conductor-0.5.1
    app.kubernetes.io/name: conductor
```