### PR TITLE
make sure to suspend backups if the instance is hibernated

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.49.2"
+version = "0.49.3"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.49.2"
+version = "0.49.3"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -2225,6 +2225,40 @@ pub(crate) async fn get_cluster(cdb: &CoreDB, ctx: Arc<Context>) -> Option<Clust
     }
 }
 
+#[instrument(skip(cdb, ctx), fields(trace_id, instance_name = %cdb.name_any()))]
+pub(crate) async fn get_scheduled_backup(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+) -> Option<ScheduledBackup> {
+    let instance_name = cdb.name_any();
+    let namespace = match cdb.namespace() {
+        Some(ns) => ns,
+        _ => {
+            error!("Namespace is not set for CoreDB {}", instance_name);
+            return None;
+        }
+    };
+
+    let scheduled_backup: Api<ScheduledBackup> = Api::namespaced(ctx.client.clone(), &namespace);
+    let sbu = scheduled_backup.get(&instance_name).await;
+
+    match sbu {
+        Ok(scheduled_backup) => {
+            debug!("ScheduledBackup {} exists", instance_name);
+            Some(scheduled_backup)
+        }
+        // return Ok(false) if the cluster does not exist (404)
+        Err(kube::Error::Api(ae)) if ae.code == 404 => {
+            debug!("ScheduledBackup {} does not exist", instance_name);
+            None
+        }
+        Err(_e) => {
+            error!("Error getting ScheduledBackup: {}", instance_name);
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -147,7 +147,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     });
 
     // Check if scheduled_backup_suspend_status=false and cdb.spec.stop=true.  If so then patch the scheduled backup suspend status to true
-    if !scheduled_backup_suspend_status && cdb.spec.stop {
+    if scheduled_backup_suspend_status != cdb.spec.stop {
         patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec.clone()).await?;
         info!(
             "Toggled scheduled backup suspend of {} to '{}'",
@@ -174,12 +174,6 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     info!(
         "Toggled hibernation annotation of {} to '{}'",
         name, hibernation_value
-    );
-
-    patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec.clone()).await?;
-    info!(
-        "Toggled scheduled backup suspend of {} to '{}'",
-        name, scheduled_backup_value
     );
 
     let mut status = cdb.status.clone().unwrap_or_default();

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -1,5 +1,5 @@
 use crate::apis::coredb_types::CoreDB;
-use crate::cloudnativepg::cnpg::get_cluster;
+use crate::cloudnativepg::cnpg::{get_cluster, get_scheduled_backup};
 use crate::Error;
 
 use crate::{patch_cdb_status_merge, requeue_normal_with_jitter, Context};
@@ -39,6 +39,15 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         Some(cluster) => cluster,
         None => {
             warn!("Cluster {} does not exist yet. Proceeding...", name);
+            return Ok(());
+        }
+    };
+
+    let scheduled_backup = get_scheduled_backup(cdb, ctx.clone()).await;
+    let scheduled_backup = match scheduled_backup {
+        Some(scheduled_backup) => scheduled_backup,
+        None => {
+            warn!("ScheduledBackup {} does not exist yet. Proceeding...", name);
             return Ok(());
         }
     };
@@ -129,12 +138,22 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         }
     });
 
+    let scheduled_backup_suspend_status = scheduled_backup.spec.suspend.unwrap_or_default();
     let scheduled_backup_value = cdb.spec.stop;
     let patch_scheduled_backup_spec = json!({
         "spec": {
             "suspend": scheduled_backup_value
         }
     });
+
+    // Check if scheduled_backup_suspend_status=false and cdb.spec.stop=true.  If so then patch the scheduled backup suspend status to true
+    if !scheduled_backup_suspend_status && cdb.spec.stop {
+        patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec.clone()).await?;
+        info!(
+            "Toggled scheduled backup suspend of {} to '{}'",
+            name, scheduled_backup_value
+        );
+    }
 
     // Check the annotation we are about to match was already there
 
@@ -157,7 +176,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         name, hibernation_value
     );
 
-    patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec).await?;
+    patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec.clone()).await?;
     info!(
         "Toggled scheduled backup suspend of {} to '{}'",
         name, scheduled_backup_value

--- a/tembo-operator/src/extensions/toggle.rs
+++ b/tembo-operator/src/extensions/toggle.rs
@@ -484,7 +484,7 @@ async fn get_trunk_project_version(
     // Check if version is provided in cdb.spec.trunk_installs
     for trunk_install in &cdb.spec.trunk_installs {
         if trunk_install.name == trunk_project_name {
-            trunk_project_version = trunk_install.version.clone();
+            trunk_project_version.clone_from(&trunk_install.version);
         }
     }
 

--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -529,7 +529,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_latest_trunk_project_version() {
-        let result = get_latest_trunk_project_metadata("pgmq".into()).await;
+        let result = get_latest_trunk_project_metadata("pgmq").await;
         assert!(result.is_ok());
 
         let project = result.unwrap();


### PR DESCRIPTION
Add some logic to patch the `ScheduledBackup` to suspend backups for paused instances.  This causes quite a bit of contention in the CNPG operator if you do not.  Basically reconciling the backups for all paused instances every 30 seconds.


```
{"level":"info","ts":"2024-07-10T20:56:40Z","msg":"Couldn't find target pod, will retry in 30 seconds","controller":"backup","controllerGroup":"postgresql.cnpg.io","controllerKind":"Backup","Backup":{"name":"org-goracz-inst-instance-1-20240630101000","namespace":"org-goracz-inst-instance-1"},"namespace":"org-goracz-inst-instance-1","name":"org-goracz-inst-instance-1-20240630101000","reconcileID":"0188b21b-9fb8-45cf-98db-f6dcf31f42ef","uuid":"e7ba2595-3efe-11ef-8d3a-724d5e302e50","target":"org-goracz-inst-instance-1-1"}
```

Fixes: [CLOUD-1009](https://linear.app/tembo/issue/CLOUD-1009/when-pausing-an-instance-remove-the-scheduledbackup-from-the-cluster)