### PR TITLE
Scale down poolers if hiberated

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.49.3"
+version = "0.49.4"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.49.3"
+version = "0.49.4"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg_utils.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg_utils.rs
@@ -1,6 +1,7 @@
 pub use crate::{
     apis::coredb_types::CoreDB,
     cloudnativepg::clusters::{Cluster, ClusterStatusConditionsStatus},
+    cloudnativepg::poolers::Pooler,
     cloudnativepg::scheduledbackups::ScheduledBackup,
     controller,
     extensions::database_queries::is_not_restarting,
@@ -175,6 +176,39 @@ pub async fn patch_scheduled_backup_merge(
 
     Ok(())
 }
+
+// patch_pooler_merge takes a CoreDB, context and serde_json::Value and patch merges the Pooler with the new spec
+#[instrument(skip(cdb, ctx), fields(trace_id, instance_name = %cdb.name_any(), patch = %patch))]
+pub async fn patch_pooler_merge(
+    cdb: &CoreDB,
+    ctx: &Arc<Context>,
+    patch: serde_json::Value,
+) -> Result<(), Action> {
+    let name = cdb.name_any() + "-pooler";
+    let namespace = cdb.metadata.namespace.as_ref().ok_or_else(|| {
+        error!("Namespace is empty for instance: {}.", name);
+        Action::requeue(Duration::from_secs(300))
+    })?;
+
+    let pooler_api: Api<Pooler> = Api::namespaced(ctx.client.clone(), namespace);
+    let pp = PatchParams::apply("patch_merge");
+    let _ = pooler_api
+        .patch(&name, &pp, &Patch::Merge(&patch))
+        .await
+        .map_err(|e| {
+            error!("Error patching cluster: {}", e);
+            Action::requeue(Duration::from_secs(300))
+        });
+
+    Ok(())
+}
+
+// get_pooler_instances takes a CoreDB and returns an Option<i32> based if the CoreDB is hibernated
+#[instrument(skip(cdb), fields(trace_id, instance_name = %cdb.name_any()))]
+pub fn get_pooler_instances(cdb: &CoreDB) -> Option<i32> {
+    Some(if cdb.spec.stop { 0 } else { 1 })
+}
+
 // cdb: the CoreDB object
 // maybe_cluster, Option<Cluster> of the current CNPG cluster, if it exists
 // new_spec: the new Cluster spec to be applied

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -1,5 +1,7 @@
 use crate::apis::coredb_types::CoreDB;
-use crate::cloudnativepg::cnpg::{get_cluster, get_scheduled_backup};
+use crate::cloudnativepg::cnpg::{get_cluster, get_pooler, get_scheduled_backup};
+use crate::cloudnativepg::poolers::Pooler;
+use crate::cloudnativepg::scheduledbackups::ScheduledBackup;
 use crate::Error;
 
 use crate::{patch_cdb_status_merge, requeue_normal_with_jitter, Context};
@@ -11,7 +13,9 @@ use serde_json::json;
 use k8s_openapi::api::apps::v1::Deployment;
 
 use crate::app_service::manager::get_appservice_deployment_objects;
-use crate::cloudnativepg::cnpg_utils::{patch_cluster_merge, patch_scheduled_backup_merge};
+use crate::cloudnativepg::cnpg_utils::{
+    patch_cluster_merge, patch_pooler_merge, patch_scheduled_backup_merge,
+};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
@@ -27,6 +31,10 @@ use tracing::{debug, error, info, warn};
 ///
 /// Returns a normal, jittered requeue when the instance is stopped.
 pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> Result<(), Action> {
+    info!(
+        "Reconciling hibernation for CoreDB instance {}",
+        cdb.name_any()
+    );
     let name = cdb.name_any();
     let namespace = cdb.namespace().ok_or_else(|| {
         error!("Namespace is not set for CoreDB instance {}", name);
@@ -44,13 +52,20 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     };
 
     let scheduled_backup = get_scheduled_backup(cdb, ctx.clone()).await;
-    let scheduled_backup = match scheduled_backup {
-        Some(scheduled_backup) => scheduled_backup,
-        None => {
-            warn!("ScheduledBackup {} does not exist yet. Proceeding...", name);
-            return Ok(());
-        }
-    };
+    if scheduled_backup.is_none() {
+        warn!(
+            "ScheduledBackup {} does not exist or backups are disabled. Proceeding without it...",
+            name
+        );
+    }
+
+    let pooler = get_pooler(cdb, ctx.clone()).await;
+    if pooler.is_none() {
+        warn!(
+            "Pooler {} does not exist or disabled. Proceeding without it...",
+            name
+        );
+    }
 
     let client = ctx.client.clone();
     let coredbs: Api<CoreDB> = Api::namespaced(client.clone(), &namespace);
@@ -138,25 +153,25 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         }
     });
 
-    let scheduled_backup_suspend_status = scheduled_backup.spec.suspend.unwrap_or_default();
-    let scheduled_backup_value = cdb.spec.stop;
-    let patch_scheduled_backup_spec = json!({
-        "spec": {
-            "suspend": scheduled_backup_value
-        }
-    });
-
-    // Check if scheduled_backup_suspend_status=false and cdb.spec.stop=true.  If so then patch the scheduled backup suspend status to true
-    if scheduled_backup_suspend_status != cdb.spec.stop {
-        patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec.clone()).await?;
-        info!(
-            "Toggled scheduled backup suspend of {} to '{}'",
-            name, scheduled_backup_value
+    // Update ScheduledBackup if it exists
+    if let Err(action) = update_scheduled_backup(&scheduled_backup, cdb, ctx).await {
+        warn!(
+            "Error updating scheduled backup for {}. Requeuing...",
+            cdb.name_any()
         );
+        return Err(action);
+    }
+
+    // Patch the Pooler deployment to match the hibernation state
+    if let Err(action) = update_pooler_instances(&pooler, cdb, ctx).await {
+        warn!(
+            "Error updating pooler instances for {}. Requeuing...",
+            cdb.name_any()
+        );
+        return Err(action);
     }
 
     // Check the annotation we are about to match was already there
-
     if let Some(current_hibernation_setting) = cluster_annotations.get("cnpg.io/hibernation") {
         if current_hibernation_setting == hibernation_value {
             debug!(
@@ -191,5 +206,100 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         info!("Fully reconciled stopped instance {}", name);
         return Err(requeue_normal_with_jitter());
     }
+    Ok(())
+}
+
+async fn update_pooler_instances(
+    pooler: &Option<Pooler>,
+    cdb: &CoreDB,
+    ctx: &Arc<Context>,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+
+    match pooler {
+        Some(p) => {
+            let current_instances = p.spec.instances.unwrap_or(1);
+            let desired_instances = if cdb.spec.stop { 0 } else { 1 };
+
+            if current_instances != desired_instances {
+                let patch_pooler_spec = json!({
+                    "spec": {
+                        "instances": desired_instances,
+                    }
+                });
+
+                match patch_pooler_merge(cdb, ctx, patch_pooler_spec).await {
+                    Ok(_) => {
+                        info!(
+                            "Updated Pooler instances for {} from {} to {}",
+                            name, current_instances, desired_instances
+                        );
+                    }
+                    Err(e) => {
+                        error!("Failed to update Pooler instances for {}: {:?}", name, e);
+                        return Err(requeue_normal_with_jitter());
+                    }
+                }
+            } else {
+                debug!(
+                    "Pooler instances for {} already set to {}. No update needed.",
+                    name, current_instances
+                );
+            }
+        }
+        None => {
+            info!(
+                "Skipping Pooler operations as it doesn't exist for {}",
+                name
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn update_scheduled_backup(
+    scheduled_backup: &Option<ScheduledBackup>,
+    cdb: &CoreDB,
+    ctx: &Arc<Context>,
+) -> Result<(), Action> {
+    let name = cdb.name_any();
+
+    if let Some(sb) = scheduled_backup {
+        let scheduled_backup_suspend_status = sb.spec.suspend.unwrap_or_default();
+        let scheduled_backup_value = cdb.spec.stop;
+
+        if scheduled_backup_suspend_status != scheduled_backup_value {
+            let patch_scheduled_backup_spec = json!({
+                "spec": {
+                    "suspend": scheduled_backup_value
+                }
+            });
+
+            match patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec).await {
+                Ok(_) => {
+                    info!(
+                        "Toggled scheduled backup suspend of {} to '{}'",
+                        name, scheduled_backup_value
+                    );
+                }
+                Err(e) => {
+                    error!("Failed to update ScheduledBackup for {}: {:?}", name, e);
+                    return Err(requeue_normal_with_jitter());
+                }
+            }
+        } else {
+            debug!(
+                "ScheduledBackup suspend for {} already set to {}. No update needed.",
+                name, scheduled_backup_value
+            );
+        }
+    } else {
+        info!(
+            "Skipping ScheduledBackup operations as it doesn't exist for {}",
+            name
+        );
+    }
+
     Ok(())
 }

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -162,7 +162,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         return Err(action);
     }
 
-    // Patch the Pooler deployment to match the hibernation state
+    // Patch the Pooler cluster resource to match the hibernation state
     if let Err(action) = update_pooler_instances(&pooler, cdb, ctx).await {
         warn!(
             "Error updating pooler instances for {}. Requeuing...",

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -78,7 +78,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     // Conversely, setting it back to 1 if the cluster is started should reverse
     // the process.
 
-    let replicas = get_pooler_instances(cdb);
+    let replicas = if cdb.spec.stop { 0 } else { 1 };
     let replica_patch = json!({
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -115,7 +115,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
             None => continue,
         };
 
-        if replicas == spec.replicas {
+        if Some(replicas) == spec.replicas {
             continue;
         }
 

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -14,7 +14,7 @@ use k8s_openapi::api::apps::v1::Deployment;
 
 use crate::app_service::manager::get_appservice_deployment_objects;
 use crate::cloudnativepg::cnpg_utils::{
-    patch_cluster_merge, patch_pooler_merge, patch_scheduled_backup_merge,
+    get_pooler_instances, patch_cluster_merge, patch_pooler_merge, patch_scheduled_backup_merge,
 };
 use std::sync::Arc;
 use std::time::Duration;
@@ -78,7 +78,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     // Conversely, setting it back to 1 if the cluster is started should reverse
     // the process.
 
-    let replicas = if cdb.spec.stop { 0 } else { 1 };
+    let replicas = get_pooler_instances(cdb);
     let replica_patch = json!({
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -115,7 +115,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
             None => continue,
         };
 
-        if Some(replicas) == spec.replicas {
+        if replicas == spec.replicas {
             continue;
         }
 


### PR DESCRIPTION
If a `CoreDB` has a connection pooler enabled, we should scale down the `Pooler` if `CoreDB.spec.stop` is `true`

* Add logic to scale down `Pooler` type if pause/hibernation is enabled
* Modify logic to better handle disabling of backups if pause/hibernation is enabled.

Fixes: [CLOUD-1017](https://linear.app/tembo/issue/CLOUD-1017/pooler-not-spinning-down-when-instance-is-hibernated)