### PR TITLE
fix trunk ver test

### DIFF
--- a/tembo-operator/src/trunk.rs
+++ b/tembo-operator/src/trunk.rs
@@ -545,8 +545,23 @@ mod tests {
         let result = get_latest_trunk_project_metadata("pgmq").await;
         assert!(result.is_ok());
 
+        // latest pgmq release per repo
+        let url = "https://api.github.com/repos/tembo-io/pgmq/releases/latest";
+        let client = reqwest::Client::new();
+        let res = client
+            .get(url)
+            .header("User-Agent", "reqwest")
+            .send()
+            .await
+            .unwrap()
+            .json::<serde_json::Value>()
+            .await
+            .unwrap();
+        let latest_rag = res.get("tag_name").unwrap().as_str().unwrap();
+
         let project = result.unwrap();
-        assert!(project.version == "1.4.0");
+
+        assert_eq!(format!("v{}", project.version), latest_rag);
         assert!(project.name == "pgmq");
     }
 


### PR DESCRIPTION
The existing test is going to break and require an update every time pgmq releases a new version. Instead, we can check the github repo's latest release and assert based on that value.