### PR TITLE
tembo-ai add option for private loadbalancer

### DIFF
--- a/charts/tembo-ai/Chart.yaml
+++ b/charts/tembo-ai/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/tembo-ai/templates/inference-gateway/service-lb.yaml
+++ b/charts/tembo-ai/templates/inference-gateway/service-lb.yaml
@@ -7,6 +7,11 @@ metadata:
     {{- include "tembo-ai.inferenceGateway.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.inferenceGateway.internalLoadBalancer.annotations | nindent 4 }}
+    {{- if .Values.inferenceGateway.internalLoadBalancer.route53.enabled }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.inferenceGateway.internalLoadBalancer.route53.recordName }}.{{ .Values.inferenceGateway.internalLoadBalancer.route53.zoneName }}
+    external-dns.alpha.kubernetes.io/ttl: {{ .Values.inferenceGateway.internalLoadBalancer.route53.ttl | quote }}
+    {{- end }}
+
 spec:
   type: LoadBalancer
   ports:

--- a/charts/tembo-ai/templates/inference-gateway/service-lb.yaml
+++ b/charts/tembo-ai/templates/inference-gateway/service-lb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.inferenceGateway.internalLoadBalancer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "tembo-ai.fullname" . }}-gateway-internal-lb
+  labels:
+    {{- include "tembo-ai.inferenceGateway.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.inferenceGateway.internalLoadBalancer.annotations | nindent 4 }}
+spec:
+  type: LoadBalancer
+  ports:
+    - port: {{ .Values.inferenceGateway.internalLoadBalancer.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "tembo-ai.inferenceGateway.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/tembo-ai/values.yaml
+++ b/charts/tembo-ai/values.yaml
@@ -54,6 +54,13 @@ inferenceGateway:
     annotations: {}
   service:
     port: 8080
+  internalLoadBalancer:
+    enabled: false
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    port: 8080
   args: []
   command:
     - "/usr/local/bin/gateway"
@@ -82,13 +89,13 @@ inferenceService:
     tag: latest
   resources:
     requests:
-      cpu: '4'
-      memory: '16Gi'
-      nvidia.com/gpu: '1'
+      cpu: "4"
+      memory: "16Gi"
+      nvidia.com/gpu: "1"
     limits:
-      cpu: '8'
-      memory: '16Gi'
-      nvidia.com/gpu: '1'
+      cpu: "8"
+      memory: "16Gi"
+      nvidia.com/gpu: "1"
   livenessProbe:
     enabled: true
     path: /health
@@ -140,10 +147,10 @@ inferenceService:
   #   # readOnlyRootFilesystem: true
   nodeSelector: {}
   tolerations:
-  - key: "tembo.io/gpu"
-    operator: "Equal"
-    value: "true"
-    effect: "NoSchedule"
+    - key: "tembo.io/gpu"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
   affinity: {}
   podAnnotations: {}
   podSecurityContext: {}

--- a/charts/tembo-ai/values.yaml
+++ b/charts/tembo-ai/values.yaml
@@ -60,6 +60,10 @@ inferenceGateway:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
       service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       service.beta.kubernetes.io/aws-load-balancer-scheme: internal
+    route53:
+      enabled: false
+      zoneName: ""
+      recordName: "inference-gateway"
     port: 8080
   args: []
   command:


### PR DESCRIPTION
Adding support to create an internal (private) load-balancer so that the inference-gateway can be accessed from all AWS regions, not just us-east-1.

fixes: [CLOUD-1157](https://linear.app/tembo/issue/CLOUD-1157/tembo-ai-not-accessible-from-other-regions)