### PR TITLE
Bump crate version for analytics

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
The example pull request in the notion doc didn't include this and I forgot it.