### PR TITLE
add exception to egress policy for port 8080

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.49.6"
+version = "0.49.7"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.49.6"
+version = "0.49.7"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/network_policies.rs
+++ b/tembo-operator/src/network_policies.rs
@@ -311,6 +311,46 @@ pub async fn reconcile_network_policies(client: Client, namespace: &str) -> Resu
 
     apply_network_policy(namespace, &np_api, allow_proxy_to_access_tembo_ai_gateway).await?;
 
+    let allow_proxy_to_access_tembo_ai_gateway_internal_lb = serde_json::json!({
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+          "name": "allow-proxy-to-access-tembo-ai-gateway-internal-lb",
+          "namespace": format!("{namespace}"),
+        },
+        "spec": {
+          "podSelector": {
+            "matchLabels": {
+              "app": format!("{}-ai-proxy", namespace)
+            }
+          },
+          "policyTypes": ["Egress"],
+          "egress": [
+            {
+              "ports": [
+                {
+                  "port": 8080,
+                  "protocol": "TCP"
+                }
+              ],
+              "to": [
+                {
+                  "ipBlock": {
+                    "cidr": "10.0.0.0/8"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+    });
+
+    apply_network_policy(
+        namespace,
+        &np_api,
+        allow_proxy_to_access_tembo_ai_gateway_internal_lb,
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
There needs to be an exception to the `allow-system-egress` policy to allow for access to new Internal load balancer for the tembo-ai gateway.

We should allow access to `10.0.0.0/8` on port `8080`.  This will allow the `ai-proxy` pods access to the load balancer for the inference-gateway on all clusters.