### PR TITLE
update ai, mq stacks

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/apps/ai.yaml
+++ b/tembo-stacks/src/apps/ai.yaml
@@ -26,11 +26,11 @@ trunk_installs:
   - name: pg_cron
     version: 1.6.2
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: pgvector
-    version: 0.7.3
+    version: 0.7.4
   - name: vectorize
-    version: 0.17.0
+    version: 0.18.0
 extensions:
   - name: pg_cron
     locations:
@@ -41,17 +41,17 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 1.3.3
+        version: 1.4.2
   - name: vector
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.3
+        version: 0.7.4
   - name: vectorize
     locations:
       - database: postgres
         enabled: true
-        version: 0.17.0
+        version: 0.18.0
 postgres_config:
   - name: cron.host
     value: /controller/run

--- a/tembo-stacks/src/apps/embeddings.yaml
+++ b/tembo-stacks/src/apps/embeddings.yaml
@@ -57,13 +57,13 @@ trunk_installs:
   - name: pg_cron
     version: 1.6.2
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: pgvector
-    version: 0.7.3
+    version: 0.7.4
   - name: vectorize
-    version: 0.17.0
+    version: 0.18.0
   - name: vectorscale
-    version: 0.2.0
+    version: 0.3.0
 extensions:
   - name: pg_cron
     locations:
@@ -74,26 +74,26 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 1.3.3
+        version: 1.4.2
   - name: vector
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.3
+        version: 0.7.4
   - name: vectorize
     locations:
       - database: postgres
         enabled: true
-        version: 0.17.0
+        version: 0.18.0
   - name: vectorscale
     locations:
       - database: postgres
         enabled: true
-        version: 0.2.0
+        version: 0.3.0
 postgres_config:
   - name: cron.host
     value: /controller/run
   - name: vectorize.host
     value: postgresql:///postgres?host=/controller/run
   - name: vectorize.embedding_service_url
-    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1/embeddings
+    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1

--- a/tembo-stacks/src/stacks/specs/machine_learning.yaml
+++ b/tembo-stacks/src/stacks/specs/machine_learning.yaml
@@ -23,33 +23,33 @@ postgres_config:
   - name: shared_preload_libraries
     value: vectorize,pg_stat_statements,pgml,pg_cron,pg_later
   - name: vectorize.embedding_service_url
-    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1/embeddings
+    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1
   - name: pglater.host
     value: postgresql:///postgres?host=/controller/run
 trunk_installs:
   - name: pgvector
-    version: 0.7.3
+    version: 0.7.4
   - name: postgresml
     version: 2.7.1
   - name: pg_cron
     version: 1.6.2
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: vectorize
-    version: 0.17.0
+    version: 0.18.0
   - name: pg_later
     version: 0.1.0
   - name: plpython3u
     version: 1.0.0
   - name: vectorscale
-    version: 0.2.0
+    version: 0.3.0
 extensions:
   # trunk project pg_vector
   - name: vector
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.3
+        version: 0.7.4
   # trunk project postgresml
   - name: pgml
     locations:
@@ -65,12 +65,12 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 1.3.3
+      version: 1.4.2
   - name: vectorize
     locations:
     - database: postgres
       enabled: true
-      version: 0.17.0
+      version: 0.18.0
   - name: pg_later
     locations:
     - database: postgres
@@ -85,4 +85,4 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.2.0
+        version: 0.3.0

--- a/tembo-stacks/src/stacks/specs/message_queue.yaml
+++ b/tembo-stacks/src/stacks/specs/message_queue.yaml
@@ -51,7 +51,7 @@ appServices:
         memory: 100Mi
 trunk_installs:
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: pg_partman
     version: 4.7.4
   - name: parquet_s3_fdw
@@ -63,13 +63,13 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 1.3.3
+        version: 1.4.2
       - database: app
         enabled: true
-        version: 1.3.3
+        version: 1.4.2
       - database: template1
         enabled: true
-        version: 1.3.3
+        version: 1.4.2
   - name: pg_partman
     locations:
       - database: postgres

--- a/tembo-stacks/src/stacks/specs/rag.yaml
+++ b/tembo-stacks/src/stacks/specs/rag.yaml
@@ -85,11 +85,11 @@ appServices:
         initialDelaySeconds: 10
 trunk_installs:
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: vectorize
-    version: 0.17.0
+    version: 0.18.0
   - name: pgvector
-    version: 0.7.3
+    version: 0.7.4
   - name: pg_stat_statements
     version: 1.10.0
 extensions:
@@ -97,7 +97,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.3
+        version: 0.7.4
   - name: pg_cron
     locations:
     - database: postgres
@@ -107,12 +107,12 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 1.3.3
+      version: 1.4.2
   - name: vectorize
     locations:
     - database: postgres
       enabled: true
-      version: 0.17.0
+      version: 0.18.0
   - name: pg_stat_statements
     locations:
       - database: postgres
@@ -147,7 +147,7 @@ postgres_config:
   - name: shared_preload_libraries
     value: vectorize,pg_stat_statements,pg_cron
   - name: vectorize.embedding_service_url
-    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1/embeddings
+    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1
   - name: vectorize.tembo_service_url
     value: http://${NAMESPACE}-ai-proxy:8080/v1
   - name: vectorize.tembo_jwt

--- a/tembo-stacks/src/stacks/specs/vectordb.yaml
+++ b/tembo-stacks/src/stacks/specs/vectordb.yaml
@@ -63,21 +63,21 @@ appServices:
         initialDelaySeconds: 10
 trunk_installs:
   - name: pgmq
-    version: 1.3.3
+    version: 1.4.2
   - name: vectorize
-    version: 0.17.0
+    version: 0.18.0
   - name: pgvector
-    version: 0.7.3
+    version: 0.7.4
   - name: pg_stat_statements
     version: 1.10.0
   - name: vectorscale
-    version: 0.2.0
+    version: 0.3.0
 extensions:
   - name: vector
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.3
+        version: 0.7.4
   - name: pg_cron
     locations:
     - database: postgres
@@ -87,12 +87,12 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 1.3.3
+      version: 1.4.2
   - name: vectorize
     locations:
     - database: postgres
       enabled: true
-      version: 0.17.0
+      version: 0.18.0
   - name: pg_stat_statements
     locations:
       - database: postgres
@@ -102,7 +102,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.2.0
+        version: 0.3.0
 postgres_config_engine: standard
 postgres_config:
   - name: cron.host
@@ -132,4 +132,4 @@ postgres_config:
   - name: shared_preload_libraries
     value: vectorize,pg_stat_statements,pg_cron
   - name: vectorize.embedding_service_url
-    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1/embeddings
+    value: http://${NAMESPACE}-embeddings.${NAMESPACE}.svc.cluster.local:3000/v1


### PR DESCRIPTION
pgvector      -> 0.7.4
pgmq           -> 1.4.2
vectorize     -> 0.18.0 (removes `/embeddings` from the `vectorize.embedding_service_url` value)
vectorscale -> 0.3.0