### PR TITLE
Change lakehouse to analytics

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.15.2"
+version = "0.15.3"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/analytics.yaml
+++ b/tembo-stacks/src/stacks/specs/analytics.yaml
@@ -34,8 +34,8 @@ trunk_installs:
     version: 4.7.4
   - name: pg_cron
     version: 1.6.2
-  - name: pg_lakehouse
-    version: 0.9.0
+  - name: pg_analytics
+    version: 0.1.2
 extensions:
   - name: pg_stat_statements
     locations:
@@ -53,9 +53,9 @@ extensions:
     - database: postgres
       enabled: true
       version: 1.6.2
-  - name: pg_lakehouse
-    description: pg_lakehouse
+  - name: pg_analytics
+    description: pg_analytics
     locations:
     - database: postgres
       enabled: true
-      version: 0.9.0
+      version: 0.1.2


### PR DESCRIPTION
ParadeDB has split its monorepo into pieces and renamed pg_lakehouse to simply pg_analytics. Our analytics stack should follow suit.