### PR TITLE
Add `extraEnv` to Conductor Chart Values

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/conductor/templates/deployment.yaml
+++ b/charts/conductor/templates/deployment.yaml
@@ -46,6 +46,12 @@ spec:
           - name: RUST_LOG
             value: {{ .Values.logLevel }}
           {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 10 }}{{- end }}
+          {{- with (index .Values ).extraEnv }}
+          {{- range . }}
+          - name: {{ .name }}
+            value: {{ tpl (.value | quote) $ }}
+          {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/conductor/templates/metrics-deployment.yaml
+++ b/charts/conductor/templates/metrics-deployment.yaml
@@ -48,6 +48,12 @@ spec:
           - name: RUST_LOG
             value: {{ .Values.logLevel }}
           {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 10 }}{{- end }}
+          {{- with (index .Values ).extraEnv }}
+          {{- range . }}
+          - name: {{ .name }}
+            value: {{ tpl (.value | quote) $ }}
+          {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/conductor/templates/watcher-deployment.yaml
+++ b/charts/conductor/templates/watcher-deployment.yaml
@@ -46,6 +46,12 @@ spec:
           - name: RUST_LOG
             value: {{ .Values.logLevel }}
           {{- if .Values.env }}{{ .Values.env | default list | toYaml | nindent 10 }}{{- end }}
+          {{- with (index .Values ).extraEnv }}
+          {{- range . }}
+          - name: {{ .name }}
+            value: {{ tpl (.value | quote) $ }}
+          {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/conductor/values.yaml
+++ b/charts/conductor/values.yaml
@@ -56,3 +56,5 @@ env:
       secretKeyRef:
         name: data-plane
         key: _data-plane_postgres_connection_string
+extraEnv: []
+


### PR DESCRIPTION
- Add `extraEnv` value to conductor chart
- Include in all deployment templates