### PR TITLE
Use `create_partitioned` in Conductor Metrics Reporter

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "controller"
-version = "0.49.8"
+version = "0.49.10"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/metrics_reporter.rs
+++ b/conductor/src/metrics_reporter.rs
@@ -42,7 +42,7 @@ pub async fn run_metrics_reporter() -> Result<()> {
         env::var("METRICS_EVENTS_QUEUE").expect("METRICS_EVENTS_QUEUE must be set");
 
     queue.init().await?;
-    queue.create(&metrics_events_queue).await?;
+    queue.create_partitioned(&metrics_events_queue).await?;
 
     let polling_interval_seconds = 60;
     let number_of_metrics = metrics.len();


### PR DESCRIPTION
Update `queue.create()` in conductor metrics reporter to `queue.create_partitioned()`. This has been causing a race condition issue in initial Self Hosted installations: https://linear.app/tembo/issue/SLF-32/handle-race-condition-between-control-plane-and-conductor.

_**This is one of 3 places where we have code to create this queue, so we could potentially remove this line here. We also create this queue in:**_
- https://github.com/tembo-io/control-plane/blob/a50d105d546f87d2156dd3b8c7d2e516649e287a/cp-webserver/src/dataplane.rs#L251-L265
- https://github.com/tembo-io/tembo/blob/f2adf01775f978f643057d8558a862539eb50b09/conductor/src/main.rs#L89
