### PR TITLE
deletes cf stack after instance is stopped

### DIFF
--- a/conductor/README.md
+++ b/conductor/README.md
@@ -28,9 +28,9 @@ Prerequisites:
 
    `❯ just run-postgres`
 
-4. Run Conductor
+4. Run & watch Conductor
 
-   `❯ just run-local`
+   `❯ just watch`
 
 6. Run unit and functional tests
 

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -430,10 +430,8 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                 let spec_js = serde_json::to_string(&current_spec.spec).unwrap();
                 debug!("dbname: {}, current_spec: {:?}", &namespace, spec_js);
 
-                if read_msg.message.event_type == Event::Stop {
-                    if is_cloud_formation {
-                        let status = current_spec.status.clone().unwrap();
-
+                if is_cloud_formation && read_msg.message.event_type == Event::Stop {
+                    if let Some(status) = current_spec.clone().status {
                         match status.running {
                             false => {
                                 info!("{}: Deleting cloudformation stack", read_msg.msg_id);


### PR DESCRIPTION
This is done so that the `iam-role` created using cloud formation gets deleted if the instance is stopped(paused) to avoid reaching the `iam-role` per account limit. It will get recreated when the instance is started back up. 