### PR TITLE
Bump `google-cloud-storage` crate to 0.22.1

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1455,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8be793a50f2edd9d910dfb72f881f08e8b21ed34827046fc43ba6e6f1c01a7"
+checksum = "c7347a3d65cd64db51e5b4aebf0c68c484042948c6d53f856f58269bc9816360"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -35,7 +35,7 @@ sqlx = { version = "0.7", features = ["runtime-tokio-native-tls", "postgres"] }
 anyhow = "1.0.82"
 serde_yaml = "0.9.34"
 reqwest = { version = "0.12.3", features = ["json"] }
-google-cloud-storage = "0.22"
+google-cloud-storage = "0.22.1"
 
 [dependencies.kube]
 features = ["runtime", "client", "derive"]

--- a/conductor/src/gcp/bucket_manager.rs
+++ b/conductor/src/gcp/bucket_manager.rs
@@ -270,7 +270,7 @@ impl BucketIamManager {
     fn create_bucket_condition(&self, bucket_name: &str, instance_name: &str) -> Condition {
         Condition {
             title: "allow-bucket-and-path".to_string(),
-            description: "Conductor managed storage bucket IAM policy condition".to_string(),
+            description: Some("Conductor managed storage bucket IAM policy condition".to_string()),
             expression: format!(
                 r#"(resource.type == "storage.googleapis.com/Bucket") || (resource.type == "storage.googleapis.com/Object" && resource.name.startsWith("projects/_/buckets/{}/objects/{}/{}"))"#,
                 bucket_name, BUCKET_PATH_PREFIX, instance_name

--- a/conductor/src/gcp/iam_builder.rs
+++ b/conductor/src/gcp/iam_builder.rs
@@ -121,7 +121,7 @@ mod tests {
     fn test_add_condition() {
         let condition = Condition {
             title: "test".to_string(),
-            description: "test condition".to_string(),
+            description: Some("test condition".to_string()),
             expression: "resource.type == \"storage.googleapis.com/Bucket\") || (resource.type == \"storage.googleapis.com/Object\"".to_string(),
         };
         let binding = IamBindingBuilder::new()
@@ -138,7 +138,7 @@ mod tests {
     fn test_build_with_all_options() {
         let condition = Condition {
             title: "test".to_string(),
-            description: "test condition".to_string(),
+            description: Some("test condition".to_string()),
             expression: "resource.type == \"storage.googleapis.com/Bucket\") || (resource.type == \"storage.googleapis.com/Object\"".to_string(),
         };
         let binding = IamBindingBuilder::new()


### PR DESCRIPTION
For some reason, our CI is not respecting our pinned version `0.22.0` for crate `google-cloud-storage` in `conductor`. It's installing version `0.22.1` during build, and there are some changes that cause the build to fail. Example failure in main branch:
https://github.com/tembo-io/tembo/actions/runs/11001332020/job/30545769062

This bumps the crate and applies necessary changes, fixing the CI failure.