### PR TITLE
tembo-cli: fix clippy + update tembo-stacks and controller crates

### DIFF
--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -775,9 +775,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "controller"
-version = "0.47.3"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908fdd592e8580af4fb1b970e93a6c7ba36a77393d87e814831f05dc4e023c7f"
+checksum = "52a091a6cdf7977042f7d00a0992e1f977b746a9f4686486e6a23c5cf193229c"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -4405,18 +4405,19 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.7.3"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2381329dc54a5a372fdb31f00f97d732d28988af049f9f8b8522623babcf02"
+checksum = "10e27387bf43862850fe812887bdb57e84ffa1e6a829181602bca2dd33fd5da6"
 dependencies = [
  "anyhow",
+ "clap",
  "controller",
  "futures",
  "k8s-openapi",
  "lazy_static",
- "regex",
  "schemars",
  "serde",
+ "serde_json",
  "serde_yaml",
  "strum",
  "strum_macros",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -65,7 +65,7 @@ tokio = { version = "1.26.0", features = [
 tungstenite ="0.21.0"
 futures-util = "0.3.30"
 dirs = "5.0.1"
-controller = "0.47.0"
+controller = "0.50.0"
 sqlx = { version = "0.8.2", features = ["runtime-tokio-native-tls", "postgres", "chrono", "json"] }
 base64 = "0.21.5"
 colorful = "0.2.2"
@@ -75,7 +75,7 @@ tiny-gradient = "0.1.0"
 urlencoding = "2.1.3"
 spinoff = "0.8.0"
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"], default-features = false }
-tembo-stacks = "0.7.0"
+tembo-stacks = "0.16.2"
 itertools = "0.12.1"
 random-string = "1.1.0"
 test-case = "=2.0.0-rc2"

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -268,7 +268,7 @@ fn docker_apply_instance(
         let mut file_path = PathBuf::from(FileUtils::get_current_working_dir());
         let stack_file = instance_setting.stack_file.clone().unwrap();
         let cleaned_stack_file = stack_file.trim_matches('"');
-        file_path.push(format!("{}", cleaned_stack_file));
+        file_path.push(cleaned_stack_file);
 
         let config_data = fs::read_to_string(&file_path).expect("File not found in the directory");
         stack = serde_yaml::from_str(&config_data).expect("Invalid YAML File");
@@ -685,7 +685,7 @@ fn get_create_instance(
         )
         .unwrap(),
         instance_name: instance_settings.instance_name.clone(),
-        stack_type: StackType::from_str(&instance_settings.stack_type.as_ref().unwrap()).unwrap(),
+        stack_type: StackType::from_str(instance_settings.stack_type.as_ref().unwrap()).unwrap(),
         storage: Storage::from_str(instance_settings.storage.as_str()).unwrap(),
         replicas: Some(instance_settings.replicas),
         app_services: get_app_services(instance_settings.app_services.clone())?,
@@ -712,11 +712,22 @@ fn get_app_services(
     if let Some(app_services) = maybe_app_services {
         for app_type in app_services.iter() {
             match app_type {
+                tembo_stacks::apps::types::AppType::AIProxy(maybe_app_config) => vec_app_types
+                    .push(temboclient::models::AppType::new(
+                        get_final_app_config(maybe_app_config)?,
+                        None, 
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    )),
                 tembo_stacks::apps::types::AppType::RestAPI(maybe_app_config) => vec_app_types
                     .push(temboclient::models::AppType::new(
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
+                        None, 
                         None,
                         None,
                         None,
@@ -724,6 +735,7 @@ fn get_app_services(
                 tembo_stacks::apps::types::AppType::HTTP(maybe_app_config) => {
                     vec_app_types.push(temboclient::models::AppType::new(
                         None,
+                        None, 
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
@@ -735,6 +747,7 @@ fn get_app_services(
                     vec_app_types.push(temboclient::models::AppType::new(
                         None,
                         None,
+                        None, 
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
@@ -744,6 +757,7 @@ fn get_app_services(
                 tembo_stacks::apps::types::AppType::Embeddings(maybe_app_config) => vec_app_types
                     .push(temboclient::models::AppType::new(
                         None,
+                        None, 
                         None,
                         None,
                         get_final_app_config(maybe_app_config)?,
@@ -754,13 +768,14 @@ fn get_app_services(
                     .push(temboclient::models::AppType::new(
                         None,
                         None,
+                        None, 
                         None,
                         None,
                         get_final_app_config(maybe_app_config)?,
                         None,
                     )),
                 tembo_stacks::apps::types::AppType::Custom(_) => vec_app_types.push(
-                    temboclient::models::AppType::new(None, None, None, None, None, None),
+                    temboclient::models::AppType::new(None, None, None, None, None, None, None),
                 ),
             }
         }
@@ -944,7 +959,7 @@ fn get_extensions(
                 vec![ExtensionInstallLocation {
                     database: Some("postgres".to_string()),
                     schema: None,
-                    version: version,
+                    version,
                     enabled: extension.enabled.unwrap_or(false),
                 }];
 
@@ -1002,7 +1017,7 @@ fn get_trunk_installs(
             if extension.trunk_project.is_some() {
                 vec_trunk_installs.push(TrunkInstall {
                     name: extension.trunk_project.unwrap(),
-                    version: version,
+                    version,
                 });
             }
         }

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -109,7 +109,7 @@ pub fn execute(
 
 fn validate_overlay(merge_path: &str) -> Result<(), anyhow::Error> {
     let mut file_path = PathBuf::from(FileUtils::get_current_working_dir());
-    file_path.push(format!("{}", merge_path));
+    file_path.push(merge_path);
 
     let contents = fs::read_to_string(&file_path)?;
     let config: Result<HashMap<String, InstanceSettings>, toml::de::Error> =
@@ -262,22 +262,21 @@ fn docker_apply_instance(
         instance_setting.instance_name.clone(),
         instance_setting.instance_name.clone(),
     )?;
-    let stack: Stack;
 
-    if instance_setting.stack_file.is_some() {
+    let stack: Stack = if instance_setting.stack_file.is_some() {
         let mut file_path = PathBuf::from(FileUtils::get_current_working_dir());
         let stack_file = instance_setting.stack_file.clone().unwrap();
         let cleaned_stack_file = stack_file.trim_matches('"');
         file_path.push(cleaned_stack_file);
 
         let config_data = fs::read_to_string(&file_path).expect("File not found in the directory");
-        stack = serde_yaml::from_str(&config_data).expect("Invalid YAML File");
+        serde_yaml::from_str(&config_data).expect("Invalid YAML File")
     } else {
         let stack_type =
             ControllerStackType::from_str(&instance_setting.stack_type.clone().unwrap())
                 .unwrap_or(ControllerStackType::Standard);
-        stack = get_stack(stack_type);
-    }
+        get_stack(stack_type)
+    };
 
     let extensions = merge_options(
         stack.extensions.clone(),

--- a/tembo-cli/src/cmd/apply.rs
+++ b/tembo-cli/src/cmd/apply.rs
@@ -715,7 +715,7 @@ fn get_app_services(
                 tembo_stacks::apps::types::AppType::AIProxy(maybe_app_config) => vec_app_types
                     .push(temboclient::models::AppType::new(
                         get_final_app_config(maybe_app_config)?,
-                        None, 
+                        None,
                         None,
                         None,
                         None,
@@ -727,7 +727,7 @@ fn get_app_services(
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
-                        None, 
+                        None,
                         None,
                         None,
                         None,
@@ -735,7 +735,7 @@ fn get_app_services(
                 tembo_stacks::apps::types::AppType::HTTP(maybe_app_config) => {
                     vec_app_types.push(temboclient::models::AppType::new(
                         None,
-                        None, 
+                        None,
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
@@ -747,7 +747,7 @@ fn get_app_services(
                     vec_app_types.push(temboclient::models::AppType::new(
                         None,
                         None,
-                        None, 
+                        None,
                         get_final_app_config(maybe_app_config)?,
                         None,
                         None,
@@ -757,7 +757,7 @@ fn get_app_services(
                 tembo_stacks::apps::types::AppType::Embeddings(maybe_app_config) => vec_app_types
                     .push(temboclient::models::AppType::new(
                         None,
-                        None, 
+                        None,
                         None,
                         None,
                         get_final_app_config(maybe_app_config)?,
@@ -768,7 +768,7 @@ fn get_app_services(
                     .push(temboclient::models::AppType::new(
                         None,
                         None,
-                        None, 
+                        None,
                         None,
                         None,
                         get_final_app_config(maybe_app_config)?,

--- a/tembo-cli/src/cmd/login.rs
+++ b/tembo-cli/src/cmd/login.rs
@@ -49,7 +49,7 @@ struct TokenRequest {
 pub fn execute(login_cmd: LoginCommand) -> Result<(), anyhow::Error> {
     let _ = list_context();
     let context_file_path = tembo_context_file_path();
-    let contents = fs::read_to_string(&context_file_path)?;
+    let contents = fs::read_to_string(context_file_path)?;
     let data: Context = toml::from_str(&contents)?;
 
     match (&login_cmd.organization_id, &login_cmd.profile) {
@@ -110,7 +110,7 @@ async fn handle_tokio(login_url: String, cmd: &LoginCommand) -> Result<(), anyho
 
     let result = time::timeout(Duration::from_secs(30), notify.notified()).await;
     if let Some(token) = shared_state_clone.token.lock().unwrap().as_ref() {
-        let _ = execute_command(&cmd, token);
+        let _ = execute_command(cmd, token);
     } else {
         println!("No token was received.");
     }
@@ -275,7 +275,6 @@ pub fn update_profile(
 
 fn append_to_file(file_path: &str, content: String) -> io::Result<()> {
     let mut file = OpenOptions::new()
-        .write(true)
         .append(true)
         .open(file_path)?;
     writeln!(file, "{}", content)?;

--- a/tembo-cli/src/cmd/login.rs
+++ b/tembo-cli/src/cmd/login.rs
@@ -274,9 +274,7 @@ pub fn update_profile(
 }
 
 fn append_to_file(file_path: &str, content: String) -> io::Result<()> {
-    let mut file = OpenOptions::new()
-        .append(true)
-        .open(file_path)?;
+    let mut file = OpenOptions::new().append(true).open(file_path)?;
     writeln!(file, "{}", content)?;
     Ok(())
 }

--- a/tembo-cli/src/cmd/logs.rs
+++ b/tembo-cli/src/cmd/logs.rs
@@ -328,7 +328,7 @@ fn beautify_logs(json_data: &str, app_name: Option<String>) -> Result<()> {
         }
     }
 
-    for (_date_time, logs) in &entries {
+    for logs in entries.values() {
         for log in logs {
             println!("{}", log);
         }

--- a/tembo-cli/src/cmd/logs.rs
+++ b/tembo-cli/src/cmd/logs.rs
@@ -167,7 +167,7 @@ async fn fetch_logs_websocket(
     );
     let mut key = [0u8; 16];
     rand::thread_rng().fill(&mut key);
-    let sec_websocket_key = general_purpose::STANDARD.encode(&key);
+    let sec_websocket_key = general_purpose::STANDARD.encode(key);
 
     let url = Url::parse(&ws_url)?;
     let host = url
@@ -319,7 +319,7 @@ fn beautify_logs(json_data: &str, app_name: Option<String>) -> Result<()> {
                                 };
                                 entries
                                     .entry(date_time)
-                                    .or_insert_with(Vec::new)
+                                    .or_default()
                                     .push(log_detail);
                             }
                             _ => eprintln!("Invalid or ambiguous timestamp: {}", unix_timestamp),

--- a/tembo-cli/src/cmd/logs.rs
+++ b/tembo-cli/src/cmd/logs.rs
@@ -317,10 +317,7 @@ fn beautify_logs(json_data: &str, app_name: Option<String>) -> Result<()> {
                                         &value[1]
                                     ),
                                 };
-                                entries
-                                    .entry(date_time)
-                                    .or_default()
-                                    .push(log_detail);
+                                entries.entry(date_time).or_default().push(log_detail);
                             }
                             _ => eprintln!("Invalid or ambiguous timestamp: {}", unix_timestamp),
                         }

--- a/tembo-cli/src/cmd/validate.rs
+++ b/tembo-cli/src/cmd/validate.rs
@@ -36,10 +36,8 @@ pub fn execute(verbose: bool) -> Result<(), anyhow::Error> {
             tembo_credentials_file_path()
         );
         has_error = true
-    } else {
-        if get_current_context()?.target == Target::TemboCloud.to_string() {
-            list_credential_profiles()?;
-        }
+    } else if get_current_context()?.target == Target::TemboCloud.to_string() {
+        list_credential_profiles()?;
     }
     if verbose {
         info("Credentials file exists");

--- a/tembo-cli/src/cmd/validate.rs
+++ b/tembo-cli/src/cmd/validate.rs
@@ -136,7 +136,7 @@ fn validate_stack_in_toml(config: &HashMap<String, InstanceSettings>) -> Result<
             || (settings.stack_file.is_none() && settings.stack_type.is_none())
         {
             return Err(Error::msg(
-                "You can only have either a stack_file or stack_type in tembo.toml file"
+                "You can only have either a stack_file or stack_type in tembo.toml file",
             ));
         }
     }

--- a/tembo-cli/src/cmd/validate.rs
+++ b/tembo-cli/src/cmd/validate.rs
@@ -135,9 +135,9 @@ fn validate_stack_in_toml(config: &HashMap<String, InstanceSettings>) -> Result<
         if (settings.stack_file.is_some() && settings.stack_type.is_some())
             || (settings.stack_file.is_none() && settings.stack_type.is_none())
         {
-            return Err(Error::msg(format!(
+            return Err(Error::msg(
                 "You can only have either a stack_file or stack_type in tembo.toml file"
-            )));
+            ));
         }
     }
 

--- a/tembo-cli/temboclient/src/models/app_type.rs
+++ b/tembo-cli/temboclient/src/models/app_type.rs
@@ -10,6 +10,9 @@
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AppType {
+    #[serde(rename = "ai_proxy", deserialize_with = "Option::deserialize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ai_proxy: Option<Box<crate::models::AppConfig>>,
     #[serde(rename = "restapi", deserialize_with = "Option::deserialize")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub restapi: Option<Box<crate::models::AppConfig>>,
@@ -32,6 +35,7 @@ pub struct AppType {
 
 impl AppType {
     pub fn new(
+        ai_proxy: Option<crate::models::AppConfig>,
         restapi: Option<crate::models::AppConfig>,
         http: Option<crate::models::AppConfig>,
         mq_api: Option<crate::models::AppConfig>,
@@ -40,6 +44,11 @@ impl AppType {
         custom: Option<crate::models::AppService>,
     ) -> AppType {
         AppType {
+            ai_proxy: if let Some(x) = ai_proxy {
+                Some(Box::new(x))
+            } else {
+                None
+            },
             restapi: if let Some(x) = restapi {
                 Some(Box::new(x))
             } else {


### PR DESCRIPTION
- Updates `controller` and `tembo-stacks` crates to latest version
- fixes bunch of clippy warnings
- adds implementation for ai_proxy app type

This does not fix the failing test though.