### PR TITLE
Fix disabling of VolumeSnapshots when instances are disabled

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -47,10 +47,10 @@ jobs:
           set -xe
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev git
-      - uses: azure/setup-helm@v3
-      - uses: extractions/setup-just@v1
+      - uses: azure/setup-helm@v4
+      - uses: extractions/setup-just@v2
       - name: Install kind
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@v1
         with:
           install_only: true
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -79,7 +79,7 @@ jobs:
           # Start the operator in the background
           cargo run > operator-output.txt 2>&1 &
           # Run the tests
-          cargo test --jobs 1 -- --ignored --nocapture
+          cargo test -- --ignored --nocapture
       - name: Debugging information
         if: always()
         run: |

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.50.0"
+version = "0.50.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -2243,7 +2243,7 @@ pub(crate) async fn get_scheduled_backups(cdb: &CoreDB, ctx: Arc<Context>) -> Ve
     let scheduled_backup: Api<ScheduledBackup> = Api::namespaced(ctx.client.clone(), &namespace);
 
     // Create a ListParams object to filter the ScheduledBackups
-    let lp = ListParams::default().fields(&format!("metadata.name={}", instance_name));
+    let lp = ListParams::default().fields(&format!("metadata.namespace={}", instance_name));
 
     match scheduled_backup.list(&lp).await {
         Ok(list) => {

--- a/tembo-operator/src/cloudnativepg/cnpg_utils.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg_utils.rs
@@ -156,6 +156,7 @@ pub async fn patch_cluster_merge(
 pub async fn patch_scheduled_backup_merge(
     cdb: &CoreDB,
     ctx: &Arc<Context>,
+    backup_name: &str,
     patch: serde_json::Value,
 ) -> Result<(), Action> {
     let name = cdb.name_any();
@@ -167,7 +168,7 @@ pub async fn patch_scheduled_backup_merge(
     let scheduled_backup_api: Api<ScheduledBackup> = Api::namespaced(ctx.client.clone(), namespace);
     let pp = PatchParams::apply("patch_merge");
     let _ = scheduled_backup_api
-        .patch(&name, &pp, &Patch::Merge(&patch))
+        .patch(backup_name, &pp, &Patch::Merge(&patch))
         .await
         .map_err(|e| {
             error!("Error patching cluster: {}", e);

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -283,6 +283,7 @@ async fn update_scheduled_backups(
     let scheduled_backup_value = cdb.spec.stop;
 
     for sb in scheduled_backups {
+        let scheduled_backup_name = sb.metadata.name.as_deref().unwrap_or(&name);
         let scheduled_backup_suspend_status = sb.spec.suspend.unwrap_or_default();
 
         if scheduled_backup_suspend_status != scheduled_backup_value {
@@ -292,7 +293,14 @@ async fn update_scheduled_backups(
                 }
             });
 
-            match patch_scheduled_backup_merge(cdb, ctx, patch_scheduled_backup_spec).await {
+            match patch_scheduled_backup_merge(
+                cdb,
+                ctx,
+                scheduled_backup_name,
+                patch_scheduled_backup_spec,
+            )
+            .await
+            {
                 Ok(_) => {
                     info!(
                         "Toggled scheduled backup suspend of {} to '{}'",

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -1324,7 +1324,7 @@ mod test {
         // Assert no tables found
         let result =
             psql_with_retry(context.clone(), coredb_resource.clone(), "\\dt".to_string()).await;
-        println!("psql out: {}", result.stdout.clone().unwrap());
+        // println!("psql out: {}", result.stdout.clone().unwrap());
         assert!(!result.stdout.clone().unwrap().contains("customers"));
 
         let result = psql_with_retry(
@@ -1341,13 +1341,13 @@ mod test {
             .to_string(),
         )
         .await;
-        println!("{}", result.stdout.clone().unwrap());
+        // println!("{}", result.stdout.clone().unwrap());
         assert!(result.stdout.clone().unwrap().contains("CREATE TABLE"));
 
         // Assert table 'customers' exists
         let result =
             psql_with_retry(context.clone(), coredb_resource.clone(), "\\dt".to_string()).await;
-        println!("{}", result.stdout.clone().unwrap());
+        // println!("{}", result.stdout.clone().unwrap());
         assert!(result.stdout.clone().unwrap().contains("customers"));
 
         let result = wait_until_psql_contains(
@@ -1359,14 +1359,15 @@ mod test {
         )
         .await;
 
-        println!("{}", result.stdout.clone().unwrap());
+        // println!("{}", result.stdout.clone().unwrap());
         assert!(result.stdout.clone().unwrap().contains("aggs_for_vecs"));
 
         // Check for metrics and availability
         let metric_name = format!("cnpg_collector_up{{cluster=\"{}\"}} 1", name);
         match wait_for_metric(pods.clone(), pod_name.to_string(), &metric_name).await {
-            Ok(result_stdout) => {
-                println!("Metric found: {}", result_stdout);
+            Ok(_result_stdout) => {
+                println!("Metric found for: {}", pod_name);
+                // println!("Metrics: {}", result_stdout);
             }
             Err(e) => {
                 panic!("Failed to find metric: {}", e);
@@ -1375,8 +1376,9 @@ mod test {
 
         // Look for the custom metric
         match wait_for_metric(pods.clone(), pod_name.to_string(), &test_metric_decr).await {
-            Ok(result_stdout) => {
-                println!("Metric found: {}", result_stdout);
+            Ok(_result_stdout) => {
+                println!("Metric found for: {}", pod_name);
+                // println!("Metrics: {}", result_stdout);
             }
             Err(e) => {
                 panic!("Failed to find metric: {}", e);


### PR DESCRIPTION
Currently the `VolumeSnapshots` are not disabled when the instance is paused/hibernated.  This leads to backed up `Backups` being created that will cause an issue with backups and snapshots when the instance is un-paused.

Fixes: [CLOUD-1340](https://linear.app/tembo/issue/CLOUD-1340/volumesnapshots-not-disabled-when-instance-is-pausedhibernated)