### PR TITLE
Add ability to deploy multiple inference-service services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,10 @@
-.github/** @sjmiller609 @nhudson @ianstanton
-charts/** @sjmiller609 @nhudson @ianstanton
-dataplane-webserver/** @sjmiller609
-tembo-operator/** @sjmiller609 @nhudson @ianstanton @ChuckHend
-conductor/** @sjmiller609 @nhudson @ianstanton @ChuckHend
-tembo-pod-init/** @nhudson
-tembo-cli/** @shahadarsh @vrmiguel @DarrenBaldwin07 @sjmiller609
-tembo-py/** @chuckhend @EvanHStanton
-tembo-stacks/** @chuckhend @jasonmp85 @shhnwz
-inference-gateway/** @chuckhend @jasonmp85 @shhnwz
+.github/** @nhudson @ianstanton @vrmiguel 
+charts/** @nhudson @ianstanton
+dataplane-webserver/** @nhudson @ianstanton @vrmiguel 
+tembo-operator/** @nhudson @ianstanton @ChuckHend @vrmiguel 
+conductor/** @nhudson @ianstanton @ChuckHend @vrmiguel 
+tembo-pod-init/** @nhudson @ianstanton
+tembo-cli/** @shahadarsh @vrmiguel @DarrenBaldwin07
+tembo-py/** @chuckhend
+tembo-stacks/** @chuckhend @jasonmp85
+inference-gateway/** @chuckhend @jasonmp85

--- a/charts/tembo-ai/templates/inference-service/_helpers.tpl
+++ b/charts/tembo-ai/templates/inference-service/_helpers.tpl
@@ -20,3 +20,58 @@ Create the name of the inference-service service account to use
 {{- define "tembo-ai.inferenceService.serviceAccountName" -}}
 {{- include "tembo-ai.fullname" . }}-service
 {{- end }}
+
+{{/* 
+Define the namespace to use across the inference-service templates
+*/}}
+{{- define "tembo-ai.namespace" -}}
+{{- default .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tembo-ai.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Merge configurations with priority to service-specific configs, handling nested structures
+*/}}
+{{- define "tembo-ai.mergeConfigs" -}}
+{{- $result := dict -}}
+{{- range $key, $value := .defaults -}}
+  {{- if kindIs "map" $value -}}
+    {{- if hasKey $.service $key -}}
+      {{- $nested := dict "defaults" $value "service" (index $.service $key) -}}
+      {{- $_ := set $result $key (fromYaml (include "tembo-ai.mergeConfigs" $nested)) -}}
+    {{- else -}}
+      {{- $_ := set $result $key $value -}}
+    {{- end -}}
+  {{- else -}}
+    {{- if not (hasKey $.service $key) -}}
+      {{- $_ := set $result $key $value -}}
+    {{- else -}}
+      {{- $_ := set $result $key (index $.service $key) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- range $key, $value := .service -}}
+  {{- if not (hasKey $result $key) -}}
+    {{- $_ := set $result $key $value -}}
+  {{- end -}}
+{{- end -}}
+{{- $result | toYaml -}}
+{{- end -}}

--- a/charts/tembo-ai/templates/inference-service/external-secret.yaml
+++ b/charts/tembo-ai/templates/inference-service/external-secret.yaml
@@ -1,21 +1,28 @@
-{{- if .Values.inferenceService.externalSecrets.secretName -}}
+{{- if .Values.inferenceService.services }}
+{{- $defaults := .Values.inferenceService.defaults }}
+{{- range $serviceName, $serviceConfig := .Values.inferenceService.services }}
+{{- $mergedConfig := fromYaml (include "tembo-ai.mergeConfigs" (dict "defaults" $defaults "service" $serviceConfig)) }}
+{{- if and (default false $mergedConfig.enabled) $mergedConfig.externalSecrets.secretName }}
+---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ include "tembo-ai.fullname" . }}-service
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}
+  namespace: {{ include "tembo-ai.namespace" $ }}
   labels:
     {{- include "tembo-ai.inferenceService.labels" . | nindent 4 }}
 spec:
-  refreshInterval: {{ .Values.inferenceService.externalSecrets.refreshInterval }}
+  refreshInterval: {{ $mergedConfig.externalSecrets.refreshInterval }}
   secretStoreRef:
-    name: {{ .Values.inferenceService.externalSecrets.parameterStore.name }}
-    kind: {{ .Values.inferenceService.externalSecrets.parameterStore.kind }}
+    name: {{ $mergedConfig.externalSecrets.parameterStore.name }}
+    kind: {{ $mergedConfig.externalSecrets.parameterStore.kind }}
   target:
     creationPolicy: 'Owner'
-    name: {{ .Values.inferenceService.externalSecrets.secretName }}
+    name: {{ $mergedConfig.externalSecrets.secretName }}
   dataFrom:
   - find:
       name:
-        regexp: {{ .Values.inferenceService.externalSecrets.secretRegex }}
+        regexp: {{ $mergedConfig.externalSecrets.secretRegex }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/tembo-ai/templates/inference-service/pod-monitor.yaml
+++ b/charts/tembo-ai/templates/inference-service/pod-monitor.yaml
@@ -1,19 +1,33 @@
-{{- if .Values.inferenceService.podMonitor.enabled -}}
+{{- if .Values.inferenceService.services }}
+{{- $defaults := .Values.inferenceService.defaults }}
+{{- $releaseName := default "release-name" .Release.Name }}
+{{- range $serviceName, $serviceConfig := .Values.inferenceService.services }}
+{{- $mergedConfig := fromYaml (include "tembo-ai.mergeConfigs" (dict "defaults" $defaults "service" $serviceConfig)) }}
+{{- if and (default false $mergedConfig.enabled) (default false $mergedConfig.podMonitor.enabled) }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "tembo-ai.fullname" . }}-service
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}
+  namespace: {{ include "tembo-ai.namespace" $ }}
   labels:
     {{- include "tembo-ai.inferenceService.labels" . | nindent 4 }}
 spec:
   podMetricsEndpoints:
-    - path: {{ .Values.inferenceService.podMonitor.path }}
-      port: {{ .Values.inferenceService.podMonitor.portName }}
+  - port: {{ $mergedConfig.podMonitor.portName }}
+    path: {{ $mergedConfig.podMonitor.path }}
+    {{- with $mergedConfig.podMonitor.interval }}
+    interval: {{ . }}
+    {{- end }}
+    {{- with $mergedConfig.podMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "tembo-ai.namespace" $ }}
   selector:
     matchLabels:
-      {{- include "tembo-ai.inferenceService.selectorLabels" . | nindent 6 }}
+      {{- include "tembo-ai.inferenceService.selectorLabels" $ | nindent 6 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/tembo-ai/templates/inference-service/service.yaml
+++ b/charts/tembo-ai/templates/inference-service/service.yaml
@@ -1,16 +1,27 @@
+{{- if .Values.inferenceService.services }}
+{{- $defaults := .Values.inferenceService.defaults }}
+{{- range $serviceName, $serviceConfig := .Values.inferenceService.services }}
+{{- $mergedConfig := fromYaml (include "tembo-ai.mergeConfigs" (dict "defaults" $defaults "service" $serviceConfig)) }}
+{{- if and (default false $mergedConfig.enabled) (default true $mergedConfig.service.enabled) }}
+---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "tembo-ai.fullname" . }}-service
+  name: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}
+  namespace: {{ include "tembo-ai.namespace" $ }}
   labels:
     {{- include "tembo-ai.inferenceService.labels" . | nindent 4 }}
 spec:
   clusterIP: None
-  type: {{ .Values.inferenceService.service.type }}
+  type: {{ $mergedConfig.service.type | default "ClusterIP" }}
   ports:
-    - port: {{ .Values.inferenceService.service.port }}
+    - port: {{ $mergedConfig.service.port }}
       targetPort: http
       protocol: TCP
       name: http
   selector:
-    {{- include "tembo-ai.inferenceService.selectorLabels" . | nindent 4 }}
+    {{- include "tembo-ai.inferenceService.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tembo-ai/templates/inference-service/serviceaccount.yaml
+++ b/charts/tembo-ai/templates/inference-service/serviceaccount.yaml
@@ -1,10 +1,31 @@
+{{- if .Values.inferenceService.services }}
+{{- $defaults := .Values.inferenceService.defaults }}
+{{- range $serviceName, $serviceConfig := .Values.inferenceService.services }}
+{{- $mergedConfig := fromYaml (include "tembo-ai.mergeConfigs" (dict "defaults" $defaults "service" $serviceConfig)) }}
+{{- if and (default false $mergedConfig.enabled) (default false $mergedConfig.serviceAccount.create) }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "tembo-ai.inferenceService.serviceAccountName" . }}
+  name: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}
+  namespace: {{ include "tembo-ai.namespace" $ }}
   labels:
-    {{- include "tembo-ai.inferenceService.labels" . | nindent 4 }}
-  {{- with .Values.inferenceService.serviceAccount.annotations }}
+    {{- include "tembo-ai.inferenceService.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ $serviceName }}
+    {{- with $mergedConfig.serviceAccount.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $mergedConfig.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- if $mergedConfig.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml $mergedConfig.serviceAccount.imagePullSecrets | nindent 2 }}
+{{- end }}
+{{- if hasKey $mergedConfig.serviceAccount "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ $mergedConfig.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tembo-ai/templates/inference-service/statefulset.yaml
+++ b/charts/tembo-ai/templates/inference-service/statefulset.yaml
@@ -1,112 +1,124 @@
+{{- if .Values.inferenceService.services }}
+{{- $defaults := .Values.inferenceService.defaults }}
+{{- range $serviceName, $serviceConfig := .Values.inferenceService.services }}
+{{- $mergedConfig := fromYaml (include "tembo-ai.mergeConfigs" (dict "defaults" $defaults "service" $serviceConfig)) }}
+{{- if (default false $mergedConfig.enabled) }}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "tembo-ai.fullname" . }}-inference-service
+  name: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}
+  namespace: {{ include "tembo-ai.namespace" $ }}
   labels:
     {{- include "tembo-ai.inferenceService.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.inferenceService.replicaCount }}
+  replicas: {{ $mergedConfig.replicaCount }}
   selector:
     matchLabels:
-      {{- include "tembo-ai.inferenceService.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "tembo-ai.fullname" . }}-inference-service
+      {{- include "tembo-ai.inferenceService.selectorLabels" $ | nindent 6 }}
+      app.kubernetes.io/component: {{ $serviceName }}
+  serviceName: {{ include "tembo-ai.fullname" $ }}-{{ $serviceName }}-inference-service
   template:
     metadata:
-      {{- with .Values.inferenceService.podAnnotations }}
+      {{- with $mergedConfig.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "tembo-ai.inferenceService.selectorLabels" . | nindent 8 }}
+        {{- include "tembo-ai.inferenceService.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: {{ $serviceName }}
     spec:
-      {{- with .Values.inferenceService.imagePullSecrets }}
+      {{- with $mergedConfig.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "tembo-ai.inferenceService.serviceAccountName" . }}
+      serviceAccountName: {{ include "tembo-ai.inferenceService.serviceAccountName" $ }}-{{ $serviceName }}
       securityContext:
-        {{- toYaml .Values.inferenceService.podSecurityContext | nindent 8 }}
+        {{- toYaml $mergedConfig.podSecurityContext | nindent 8 }}
       containers:
         - name: inference-service
           securityContext:
-            {{- toYaml .Values.inferenceService.securityContext | nindent 12 }}
-          image: "{{ .Values.inferenceService.image.repository }}:{{ .Values.inferenceService.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.inferenceService.image.pullPolicy }}
+            {{- toYaml $mergedConfig.securityContext | nindent 12 }}
+          image: "{{ $mergedConfig.image.repository }}:{{ $mergedConfig.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $mergedConfig.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.inferenceService.service.port }}
+              containerPort: {{ $mergedConfig.service.port }}
               protocol: TCP
-          {{- if and .Values.inferenceService.podMonitor.enabled (ne .Values.inferenceService.podMonitor.port "http") }}
-            - name: {{ .Values.inferenceService.podMonitor.portName }}
-              containerPort: {{ .Values.inferenceService.podMonitor.containerPort }}
+          {{- if and $mergedConfig.podMonitor.enabled (ne $mergedConfig.podMonitor.port "http") }}
+            - name: {{ $mergedConfig.podMonitor.portName }}
+              containerPort: {{ $mergedConfig.podMonitor.containerPort }}
               protocol: TCP
           {{- end }}
-          {{- if .Values.inferenceService.livenessProbe.enabled }}
+          {{- if $mergedConfig.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.inferenceService.livenessProbe.path }}
-              port: {{ .Values.inferenceService.livenessProbe.port }}
+              path: {{ $mergedConfig.livenessProbe.path }}
+              port: {{ $mergedConfig.livenessProbe.port }}
           {{- end }}
-          {{- if .Values.inferenceService.readinessProbe.enabled }}
+          {{- if $mergedConfig.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.inferenceService.readinessProbe.path }}
-              port: {{ .Values.inferenceService.readinessProbe.port }}
+              path: {{ $mergedConfig.readinessProbe.path }}
+              port: {{ $mergedConfig.readinessProbe.port }}
           {{- end }}
-          {{- if .Values.inferenceService.startupProbe.enabled }}
+          {{- if $mergedConfig.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.inferenceService.startupProbe.path }}
-              port: {{ .Values.inferenceService.startupProbe.port }}
-            failureThreshold: {{ .Values.inferenceService.startupProbe.failureThreshold }}
-            periodSeconds: {{ .Values.inferenceService.startupProbe.periodSeconds }}
+              path: {{ $mergedConfig.startupProbe.path }}
+              port: {{ $mergedConfig.startupProbe.port }}
+            failureThreshold: {{ $mergedConfig.startupProbe.failureThreshold }}
+            periodSeconds: {{ $mergedConfig.startupProbe.periodSeconds }}
           {{- end }}
           resources:
-            {{- toYaml .Values.inferenceService.resources | nindent 12 }}
-          {{- with .Values.inferenceService.args }}
+            {{- toYaml $mergedConfig.resources | nindent 12 }}
+          {{- with $mergedConfig.args }}
           args:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.inferenceService.command }}
+          {{- with $mergedConfig.command }}
           command:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.inferenceService.env }}
+          {{- with $mergedConfig.env }}
           env:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.inferenceService.persistence.enabled }}
+          {{- if $mergedConfig.persistence.enabled }}
           volumeMounts:
             - name: models
-              mountPath: {{ .Values.inferenceService.persistence.mountPath }}
+              mountPath: {{ $mergedConfig.persistence.mountPath }}
           {{- end }}
-      {{- with .Values.inferenceService.nodeSelector }}
+      {{- with $mergedConfig.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.inferenceService.affinity }}
+      {{- with $mergedConfig.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.inferenceService.tolerations }}
+      {{- with $mergedConfig.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if $mergedConfig.persistence.enabled }}
   volumeClaimTemplates:
-    {{- if .Values.inferenceService.persistence.enabled }}
     - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
         name: models
         labels:
-          {{- include "tembo-ai.inferenceService.labels" . | nindent 8 }}
+          {{- include "tembo-ai.inferenceService.labels" $ | nindent 10 }}
       spec:
         accessModes:
-          - {{ .Values.inferenceService.persistence.accessMode }}
+          - {{ $mergedConfig.persistence.accessMode }}
         resources:
           requests:
-            storage: {{ .Values.inferenceService.persistence.size }}
-        {{- if .Values.inferenceService.persistence.storageClass }}
-        storageClassName: {{ .Values.inferenceService.persistence.storageClass }}
+            storage: {{ $mergedConfig.persistence.size }}
+        {{- if $mergedConfig.persistence.storageClass }}
+        storageClassName: {{ $mergedConfig.persistence.storageClass }}
         {{- end }}
-    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/tembo-ai/values.yaml
+++ b/charts/tembo-ai/values.yaml
@@ -87,80 +87,89 @@ inferenceGateway:
   podSecurityContext: {}
 
 inferenceService:
-  image:
-    repository: quay.io/tembo/inference
-    pullPolicy: IfNotPresent
-    tag: latest
-  resources:
-    requests:
-      cpu: "4"
-      memory: "16Gi"
-      nvidia.com/gpu: "1"
-    limits:
-      cpu: "8"
-      memory: "16Gi"
-      nvidia.com/gpu: "1"
-  livenessProbe:
-    enabled: true
-    path: /health
-    port: http
-  readinessProbe:
-    enabled: true
-    path: /health
-    port: http
-  startupProbe:
-    enabled: true
-    path: /health
-    port: http
-    failureThreshold: 30
-    periodSeconds: 10
-  replicaCount: 1
-  externalSecrets:
-    refreshInterval: "5m"
-    parameterStore:
-      name: "secret-store-parameter-store"
-      kind: ClusterSecretStore
-    secretName: ~
-    secretRegex: ~
-  podMonitor:
-    enabled: false
-    path: /metrics
-    # Sometimes applications serve metrics on a different port,
-    # which makes it easier to prevent metrics from accidentally
-    # being publicly available.
-    portName: metrics
-    containerPort: 8081
-  serviceAccount:
-    create: true
-    annotations: {}
-  service:
-    port: 8000
-  args: []
-  command: []
-  env: []
-  securityContext: {}
-  #   # The most practical security settings are
-  #   # dropping all linux capabilities and
-  #   # running as non-root.
-  #   capabilities:
-  #     drop:
-  #     - ALL
-  #   runAsNonRoot: true
-  #   # Read only file system is better if the application
-  #   # can tolerate it.
-  #   # readOnlyRootFilesystem: true
-  nodeSelector: {}
-  tolerations:
-    - key: "tembo.io/gpu"
-      operator: "Equal"
-      value: "true"
-      effect: "NoSchedule"
-  affinity: {}
-  podAnnotations: {}
-  podSecurityContext: {}
-  persistence:
-    enabled: true
-    size: 100Gi
-    storageClass: ""
-    accessMode: ReadWriteOnce
-    mountPath: /root/.cache/
+  defaults:
+    image:
+      repository: quay.io/tembo/inference
+      pullPolicy: IfNotPresent
+      tag: latest
+    resources:
+      requests:
+        cpu: "4"
+        memory: "16Gi"
+        nvidia.com/gpu: "1"
+      limits:
+        cpu: "8"
+        memory: "16Gi"
+        nvidia.com/gpu: "1"
+    livenessProbe:
+      enabled: true
+      path: /health
+      port: http
+    readinessProbe:
+      enabled: true
+      path: /health
+      port: http
+    startupProbe:
+      enabled: true
+      path: /health
+      port: http
+      failureThreshold: 30
+      periodSeconds: 10
+    replicaCount: 1
+    externalSecrets:
+      refreshInterval: "5m"
+      parameterStore:
+        name: "secret-store-parameter-store"
+        kind: ClusterSecretStore
+      secretName: ~
+      secretRegex: ~
+    podMonitor:
+      enabled: false
+      path: /metrics
+      # Sometimes applications serve metrics on a different port,
+      # which makes it easier to prevent metrics from accidentally
+      # being publicly available.
+      portName: metrics
+      containerPort: 8081
+    serviceAccount:
+      create: true
+      annotations: {}
+      automountServiceAccountToken: false
+    service:
+      enabled: true
+      port: 8000
+    args: []
+    command: []
+    env: []
+    securityContext: {}
+    #   # The most practical security settings are
+    #   # dropping all linux capabilities and
+    #   # running as non-root.
+    #   capabilities:
+    #     drop:
+    #     - ALL
+    #   runAsNonRoot: true
+    #   # Read only file system is better if the application
+    #   # can tolerate it.
+    #   # readOnlyRootFilesystem: true
+    nodeSelector: {}
+    tolerations:
+      - key: "tembo.io/gpu"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+    affinity: {}
+    podAnnotations: {}
+    podSecurityContext: {}
+    persistence:
+      enabled: true
+      size: 100Gi
+      storageClass: ""
+      accessMode: ReadWriteOnce
+      mountPath: /root/.cache/
+  # Define individual inference services here
+  # services:
+  #   service1:
+  #     enabled: true
+  #   service2:
+  #     enabled: true


### PR DESCRIPTION
Update helm chart to allow for the deployment of multiple inference-services to be deployed at the same time.