### PR TITLE
Improve worker process calculations

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.16.6"
+version = "0.16.7"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Several issues with the existing approach:

  * `max_worker_processes` could be as low as `2` (in the case of a `vcpu <= 1`)
  * `max_parallel_workers` could never be lower than `8`
    * Quoting the [PostgreSQL docs](https://www.postgresql.org/docs/17/runtime-config-resource.html): _setting for this value which is higher than max_worker_processes will have no effect, since parallel workers are taken from the pool of worker processes established by that setting_
  * `max_parallel_workers_per_gather` claimed to be clamped to `8` but in fact `8` was the _minimum_ value it could take
  * `columnar_min_parallel_processes` was configured to use all available worker processes

I looked at the resultant values in a hobby instance of OLAP vs OLTP within prod Tembo cloud to see if my intuitions were correct: the max workers were `2` but max parallel workers were `8` with `8` per gather. This leaves no room for actual background processes in `pg_cron`, etc.

Looking at [PGTune](https://pgtune.leopard.in.ua)'s DW profile and the defaults in the documentation, I modified the code here to do a few things:

  * Use the ceiling of half-CPUs instead of floor for gather worker count (e.g. a value of 3 for 5 CPUs rather than 2). This doesn't matter much
  * Replace the `max` with a `min`: now gather count is clamped to `8`
  * Base max workers on max parallel workers plus some overhead. I already thought this would be safer going forward, but a blog post by another PostgreSQL service showed this was probably the best solution
  * Increased the BGW offset from `1` (for `pg_cron`) to `3`
  * Changed `columnar`'s min parallel worker count from being based on all workers to only parallel workers (leaving the overhead for other extensions)

Open questions:
  * Do we need to increase the `3` to something else?
  * Should I add a `extension_workers` and let other config engines override that as needed?
  * Is there a smarter way to figure out extension BGW overhead than baking it in here?
  * Do we want to continue the work of changing `pg_cron` to use BGWs?