### PR TITLE
Fix clippy & unit test failures

### DIFF
--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -63,6 +63,8 @@ jobs:
       - name: Cargo format and clippy
         run: |
           set -xe
+          sudo apt-get update
+          sudo apt-get install build-essential
           cd ${{ matrix.path }}
           cargo --version
           cargo fmt --all --check

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           set -xe
           sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev lsb-release wget
+          sudo apt-get install -y pkg-config libssl-dev lsb-release wget build-essential
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
           sudo apt-get update && sudo apt-get install -y postgresql-client

--- a/.github/workflows/cargo-test.yaml
+++ b/.github/workflows/cargo-test.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           set -xe
           sudo apt-get update
-          sudo apt-get install build-essential
+          sudo apt-get install -y build-essential
           cd ${{ matrix.path }}
           cargo --version
           cargo fmt --all --check

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "controller"
-version = "0.50.0"
+version = "0.50.2"
 dependencies = [
  "actix-web",
  "anyhow",


### PR DESCRIPTION
Example failure: https://github.com/tembo-io/tembo/actions/runs/11376253782/job/31648418163

```
error: linker `cc` not found
  |
  = note: No such file or directory (os error 2)

error: could not compile `proc-macro2` (build script) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `libc` (build script) due to 1 previous error
Error: Process completed with exit code 101.
```