### PR TITLE
Bump controller to 0.51.0 in stacks

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "controller"
-version = "0.50.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a091a6cdf7977042f7d00a0992e1f977b746a9f4686486e6a23c5cf193229c"
+checksum = "2063207d36cf3592636df6183758a3c1966707c59f51a093f0ccb8a21655b678"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.18.2"
+version = "0.18.3"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"
@@ -26,7 +26,7 @@ serde_json = "1.0.114"
 serde_yaml = "0.9.21"
 strum = "0.26.2"
 strum_macros = "0.26.2"
-tembo-controller = { package = "controller", version = "0.50.0" }
+tembo-controller = { package = "controller", version = "0.51.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }
 


### PR DESCRIPTION
Bump `controller` crate to 0.51.0 in stacks. Necessary for bumping controller crate in control-plane (see failures in https://github.com/tembo-io/control-plane/pull/892)