### PR TITLE
Revert `pg_search` to 0.10.3

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.18.3"
+version = "0.18.4"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/paradedb.yaml
+++ b/tembo-stacks/src/stacks/specs/paradedb.yaml
@@ -33,7 +33,7 @@ trunk_installs:
   - name: pg_analytics
     version: 0.2.1
   - name: pg_search
-    version: 0.11.0
+    version: 0.10.3
   - name: pg_cron
     version: 1.6.2
   - name: pgvector


### PR DESCRIPTION
Revert `pg_search` extension to `0.10.3` in ParadeDB stack.