### PR TITLE
Add Scarf Gateway endpoint to tembo helm charts

### DIFF
--- a/charts/tembo-ai/values.yaml
+++ b/charts/tembo-ai/values.yaml
@@ -1,6 +1,6 @@
 inferenceGateway:
   image:
-    repository: quay.io/tembo/inference-gateway
+    repository: tembo.docker.scarf.sh/tembo/inference-gateway
     pullPolicy: IfNotPresent
     tag: latest
   resources:
@@ -89,7 +89,7 @@ inferenceGateway:
 inferenceService:
   defaults:
     image:
-      repository: quay.io/tembo/inference
+      repository: tembo.docker.scarf.sh/tembo/inference
       pullPolicy: IfNotPresent
       tag: latest
     resources:

--- a/charts/tembo-operator/values.yaml
+++ b/charts/tembo-operator/values.yaml
@@ -31,7 +31,7 @@ controller:
 
   # -- The default image for the controller
   image:
-    repository: quay.io/tembo/tembo-operator
+    repository: tembo.docker.scarf.sh/tembo/tembo-operator
     pullPolicy: Always
     # -- Overrides the image tag whose default is latest
     tag: latest
@@ -127,7 +127,7 @@ pod-init:
 
   # -- The default image for the pod-init deployment
   image:
-    repository: quay.io/tembo/tembo-pod-init
+    repository: tembo.docker.scarf.sh/tembo/tembo-pod-init
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is latest
     tag: latest

--- a/charts/tembo-pod-init/values.yaml
+++ b/charts/tembo-pod-init/values.yaml
@@ -3,7 +3,7 @@ namespaceOverride:
 logLevel: info
 replicas: 1
 image:
-  repository: quay.io/tembo/tembo-pod-init 
+  repository: tembo.docker.scarf.sh/tembo/tembo-pod-init 
   tag: "{{ .Chart.AppVersion }}"
   pullPolicy: Always
 


### PR DESCRIPTION
The Scarf Gateway helps collect GDPR-compliant analytics on downloads of open source software. This change was suggested in direct discussions with the Tembo team. While the default domain that is provided here is the .docker.scarf.sh domain, the Scarf Gateway also supports utilizing a custom domain. If that is desired, we can adjust the PR accordingly here. 

@ryw 