### PR TITLE
Make sure we cleanup any VolumeSnapshots after a set retention peroid

### DIFF
--- a/tembo-operator/src/cloudnativepg/backups.rs
+++ b/tembo-operator/src/cloudnativepg/backups.rs
@@ -53,6 +53,15 @@ pub enum BackupMethod {
     VolumeSnapshot,
 }
 
+impl std::fmt::Display for BackupMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BackupMethod::BarmanObjectStore => write!(f, "barmanObjectStore"),
+            BackupMethod::VolumeSnapshot => write!(f, "volumeSnapshot"),
+        }
+    }
+}
+
 /// Configuration parameters to control the online/hot backup with volume snapshots Overrides the default settings specified in the cluster '.backup.volumeSnapshot.onlineConfiguration' stanza
 #[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
 pub struct BackupOnlineConfiguration {

--- a/tembo-operator/src/cloudnativepg/mod.rs
+++ b/tembo-operator/src/cloudnativepg/mod.rs
@@ -7,5 +7,6 @@ pub mod cnpg_utils;
 pub mod hibernate;
 pub(crate) mod placement;
 pub mod poolers;
+pub mod retention;
 mod scheduledbackups;
 pub const VOLUME_SNAPSHOT_CLASS_NAME: &str = "cnpg-snapshot-class";

--- a/tembo-operator/src/cloudnativepg/retention/mod.rs
+++ b/tembo-operator/src/cloudnativepg/retention/mod.rs
@@ -1,0 +1,1 @@
+pub mod snapshots;

--- a/tembo-operator/src/cloudnativepg/retention/snapshots.rs
+++ b/tembo-operator/src/cloudnativepg/retention/snapshots.rs
@@ -1,0 +1,117 @@
+use crate::{
+    apis::coredb_types::CoreDB,
+    cloudnativepg::backups::{Backup, BackupMethod},
+    snapshots::volumesnapshots_crd::VolumeSnapshot,
+    Context,
+};
+use chrono::{DateTime, Duration, Utc};
+use kube::{
+    api::{Api, DeleteParams, ListParams},
+    runtime::controller::Action,
+    ResourceExt,
+};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+/// Handle the cleanup of old volume snapshots and their associated backups
+pub async fn cleanup_old_volume_snapshots(
+    cdb: &CoreDB,
+    ctx: Arc<Context>,
+    retention_days: u64,
+) -> Result<(), Action> {
+    let client = ctx.client.clone();
+    let namespace = cdb.metadata.namespace.as_ref().ok_or_else(|| {
+        error!("Namespace is empty for instance: {}.", cdb.name_any());
+        Action::requeue(tokio::time::Duration::from_secs(300))
+    })?;
+    let backups_api: Api<Backup> = Api::namespaced(client.clone(), namespace);
+    let snapshots_api: Api<VolumeSnapshot> = Api::namespaced(client.clone(), namespace);
+    let cutoff_time = Utc::now() - Duration::days(retention_days as i64);
+
+    // List only volume snapshot backups
+    let lp = ListParams::default().fields(&format!("spec.method={}", BackupMethod::VolumeSnapshot));
+
+    // List all backups in the namespace
+    let backups = backups_api
+        .list(&lp)
+        .await
+        .map_err(|e| {
+            error!("Failed to list backups in namespace {}: {}", namespace, e);
+            Action::requeue(tokio::time::Duration::from_secs(300))
+        })?
+        .items;
+
+    for backup in backups {
+        if should_delete_backup(&backup, cutoff_time) {
+            delete_backup_and_snapshot(&backups_api, &snapshots_api, &backup, namespace).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn should_delete_backup(backup: &Backup, cutoff_time: DateTime<Utc>) -> bool {
+    // We only need to check timestamp now since we've already filtered for volumeSnapshot method
+    backup
+        .metadata
+        .creation_timestamp
+        .as_ref()
+        .map(|ts| ts.0 < cutoff_time)
+        .unwrap_or(false)
+}
+
+async fn delete_backup_and_snapshot(
+    backups_api: &Api<Backup>,
+    snapshots_api: &Api<VolumeSnapshot>,
+    backup: &Backup,
+    namespace: &str,
+) -> Result<(), Action> {
+    let backup_name = backup.metadata.name.as_deref().unwrap_or("unknown");
+
+    // Delete the backup first
+    match backups_api
+        .delete(backup_name, &DeleteParams::default())
+        .await
+    {
+        Ok(_) => {
+            info!(
+                "Deleted snapshot Backup '{}' for instance '{}', in namespace '{}'",
+                backup_name, namespace, namespace
+            );
+        }
+        Err(e) => {
+            warn!(
+                "Failed to delete snapshot Backup '{}' for instance '{}' in namespace '{}': {}",
+                backup_name, namespace, namespace, e
+            );
+            // If we can't delete the backup, we shouldn't try to delete the snapshot
+            return Err(Action::requeue(tokio::time::Duration::from_secs(300)));
+        }
+    }
+
+    // After successful backup deletion, try to delete the associated snapshot if it exists
+    if let Some(status) = &backup.status {
+        if let Some(snapshot_name) = &status.backup_name {
+            match snapshots_api
+                .delete(snapshot_name, &DeleteParams::default())
+                .await
+            {
+                Ok(_) => {
+                    info!(
+                        "Deleted VolumeSnapshot '{}' for instance '{}' in namespace '{}'",
+                        snapshot_name, namespace, namespace
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to delete VolumeSnapshot '{}' for instance '{}' in namespace '{}': {}",
+                        snapshot_name, namespace, namespace, e
+                    );
+                    // We still return Ok since the backup was successfully deleted
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tembo-operator/src/config.rs
+++ b/tembo-operator/src/config.rs
@@ -4,6 +4,7 @@ use std::env;
 pub struct Config {
     pub enable_backup: bool,
     pub enable_volume_snapshot: bool,
+    pub volume_snapshot_rentention_period: u64,
     pub reconcile_timestamp_ttl: u64,
     pub reconcile_ttl: u64,
 }
@@ -15,6 +16,12 @@ impl Default for Config {
             enable_volume_snapshot: from_env_default("ENABLE_VOLUME_SNAPSHOT", "false")
                 .parse()
                 .unwrap(),
+            volume_snapshot_rentention_period: from_env_default(
+                "VOLUME_SNAPSHOT_RETENTION_PERIOD",
+                "40",
+            )
+            .parse()
+            .unwrap(),
             // The time to live for recociling the reconcile timestamp
             reconcile_timestamp_ttl: from_env_default("RECONCILE_TIMESTAMP_TTL", "30")
                 .parse()


### PR DESCRIPTION
This PR adds some code to cleanup `VolumeSnapshots` and `Backup` objects from the cluster after the defined `volume_snapshot_retention_peroid` config value.

* Adds the `volume_snapshot_rentention_period` value with a default of 40 days.  This is in line with our current retention for object store backups in AWS and GCP.
* Checks for all `Backup` method types of `volumeSnapshot` older than `volume_snapshot_rentention_period`.  Then looks up the associated `VolumeSnapshot`
* Deletes the `Backup` then will delete the `VolumeSnapshot` if successful.

This is to fix an issue we are seeing with the snapshot-controller handling too many snapshots on the cluster and in our cloud services.  CNPG currently doesn't support deleting snapshots after some retention period.

fixes: [PRO-2209](https://linear.app/tembo/issue/PRO-2209/snapshot-controller-timing-out-when-querying-for-all-objects-at)