### PR TITLE
update GCP storage bucket conditions to allow for restores to work

### DIFF
--- a/conductor/src/gcp/bucket_manager.rs
+++ b/conductor/src/gcp/bucket_manager.rs
@@ -267,13 +267,14 @@ impl BucketIamManager {
     /// # Returns
     ///
     /// Returns a `Condition` instance for the specified bucket.
+
     fn create_bucket_condition(&self, bucket_name: &str, instance_name: &str) -> Condition {
         Condition {
             title: "allow-bucket-and-path".to_string(),
             description: Some("Conductor managed storage bucket IAM policy condition".to_string()),
             expression: format!(
-                r#"(resource.type == "storage.googleapis.com/Bucket") || (resource.type == "storage.googleapis.com/Object" && resource.name.startsWith("projects/_/buckets/{}/objects/{}/{}"))"#,
-                bucket_name, BUCKET_PATH_PREFIX, instance_name
+                r#"(resource.type == "storage.googleapis.com/Bucket") || (resource.type == "storage.googleapis.com/Object" && ((resource.name.startsWith("projects/_/buckets/{}/objects/{}/" )) || (resource.name.startsWith("projects/_/buckets/{}/objects/{}/{}") && request.auth.claims["storage.googleapis.com"].permission in ["storage.objects.create", "storage.objects.delete", "storage.objects.update"])))"#,
+                bucket_name, BUCKET_PATH_PREFIX, bucket_name, BUCKET_PATH_PREFIX, instance_name
             ),
         }
     }

--- a/conductor/src/gcp/iam_builder.rs
+++ b/conductor/src/gcp/iam_builder.rs
@@ -120,10 +120,10 @@ mod tests {
     #[test]
     fn test_add_condition() {
         let condition = Condition {
-            title: "test".to_string(),
-            description: Some("test condition".to_string()),
-            expression: "resource.type == \"storage.googleapis.com/Bucket\") || (resource.type == \"storage.googleapis.com/Object\"".to_string(),
-        };
+        title: "test".to_string(),
+        description: Some("test condition".to_string()),
+        expression: r#"(resource.type == "storage.googleapis.com/Bucket") || (resource.type == "storage.googleapis.com/Object" && ((resource.name.startsWith("projects/_/buckets/test-bucket/objects/v2/")) || (resource.name.startsWith("projects/_/buckets/test-bucket/objects/v2/test-instance") && request.auth.claims["storage.googleapis.com"].permission in ["storage.objects.create", "storage.objects.delete", "storage.objects.update"])))"#.to_string(),
+    };
         let binding = IamBindingBuilder::new()
             .role("admin")
             .add_member("user1@example.com")
@@ -137,10 +137,10 @@ mod tests {
     #[test]
     fn test_build_with_all_options() {
         let condition = Condition {
-            title: "test".to_string(),
-            description: Some("test condition".to_string()),
-            expression: "resource.type == \"storage.googleapis.com/Bucket\") || (resource.type == \"storage.googleapis.com/Object\"".to_string(),
-        };
+        title: "test".to_string(),
+        description: Some("test condition".to_string()),
+        expression: r#"(resource.type == "storage.googleapis.com/Bucket") || (resource.type == "storage.googleapis.com/Object" && ((resource.name.startsWith("projects/_/buckets/test-bucket/objects/v2/")) || (resource.name.startsWith("projects/_/buckets/test-bucket/objects/v2/test-instance") && request.auth.claims["storage.googleapis.com"].permission in ["storage.objects.create", "storage.objects.delete", "storage.objects.update"])))"#.to_string(),
+    };
         let binding = IamBindingBuilder::new()
             .role("admin")
             .add_member("user1@example.com")

--- a/tembo-operator/src/cloudnativepg/cnpg.rs
+++ b/tembo-operator/src/cloudnativepg/cnpg.rs
@@ -1047,16 +1047,6 @@ pub async fn reconcile_cnpg(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Actio
             None
         }
     };
-    // If we can't find the existing primary pod, returns a requeue
-    let primary_pod_cnpg = cdb
-        .primary_pod_cnpg(ctx.client.clone())
-        .await
-        .map_err(|_| {
-            let name = cdb.metadata.name.as_deref().unwrap_or("unknown");
-            error!("Failed to find Ready primary pod for {name}");
-            Action::requeue(Duration::from_secs(30))
-        })?;
-
     // Check if the CoreDB status is running: false, return requeue
     if let Some(status) = current_status {
         if !status.running {
@@ -1097,6 +1087,16 @@ pub async fn reconcile_cnpg(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Actio
                     // Check if current_shared_preload_libraries and new_libs are the same
                     if current_shared_preload_libraries != new_libs {
                         let mut libs_that_are_installed: Vec<String> = vec![];
+
+                        // If we can't find the existing primary pod, returns a requeue
+                        let primary_pod_cnpg = cdb
+                            .primary_pod_cnpg(ctx.client.clone())
+                            .await
+                            .map_err(|_| {
+                                let name = cdb.metadata.name.as_deref().unwrap_or("unknown");
+                                error!("Failed to find Ready primary pod for {name}");
+                                Action::requeue(Duration::from_secs(30))
+                            })?;
 
                         // Check if the file is already installed
                         let command = vec![


### PR DESCRIPTION
Update the GCP Storage Bucket condition to allow restores to work in GCP

fixes: [PRO-2249](https://linear.app/tembo/issue/PRO-2249/[gcp]-update-iam-condition-to-allow-for-restores-to-work)