### PR TITLE
deduplicate GCP IAM bindings

### DIFF
--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -5,7 +5,7 @@ use azure_error::AzureError;
 use azure_identity::TokenCredentialOptions;
 use azure_identity::WorkloadIdentityCredential;
 use azure_mgmt_authorization;
-use azure_mgmt_authorization::models::{RoleAssignment, RoleAssignmentProperties};
+use azure_mgmt_authorization::models::RoleAssignmentProperties;
 use azure_mgmt_msi::models::{
     FederatedIdentityCredential, FederatedIdentityCredentialProperties, Identity, TrackedResource,
 };

--- a/conductor/src/gcp/bucket_manager.rs
+++ b/conductor/src/gcp/bucket_manager.rs
@@ -112,24 +112,36 @@ impl BucketIamManager {
     /// * `condition` - The condition for the binding.
     fn update_or_create_binding(&self, policy: &mut Policy, member: &str, condition: Condition) {
         let role = self.get_storage_role();
+
+        // First, remove any bindings with the same role but different conditions
+        policy
+            .bindings
+            .retain(|b| b.role != role || b.condition.as_ref() == Some(&condition));
+
+        // Then find and update matching binding or create new one
         if let Some(binding) = self.find_matching_binding(policy, &condition) {
+            // Update existing binding
             if !binding.members.contains(&member.to_string()) {
                 binding.members.push(member.to_string());
-                info!("Added {} to existing binding.", member);
+                info!("Updated {} to existing binding", member);
             } else {
                 warn!(
-                    "Member {} already exists in the binding. No changes made.",
+                    "Member {} already exists in the binding, no changes made",
                     member
                 );
             }
         } else {
+            // Create new binding
             let new_binding = self.create_new_binding(member.to_string(), condition);
             policy.bindings.push(new_binding);
             info!(
-                "Created new binding for {} with role {} and condition.",
+                "Created new binding for {} with role {} and condition",
                 member, role
             );
         }
+
+        // Clean up any empty bindings
+        policy.bindings.retain(|b| !b.members.is_empty());
     }
 
     /// Finds a matching binding in the policy based on the role and condition.

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -993,6 +993,7 @@ async fn init_gcp_storage_workload_identity(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn init_azure_storage_workload_identity(
     is_azure: bool,
     read_msg: &Message<CRUDevent>,


### PR DESCRIPTION
In it's current form the IAM policy condition that is applied is duplicated if updated.  This change will deduplicate the IAM policy condition and set a single condition on each IAM policy.

Clean up some clippy warnings

Fixes: [PRO-2249](https://linear.app/tembo/issue/PRO-2249/[gcp]-update-iam-condition-to-allow-for-restores-to-work)