### PR TITLE
update conductor helm chart, fix resource group names

### DIFF
--- a/charts/conductor/Chart.yaml
+++ b/charts/conductor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/conductor/templates/_helpers.tpl
+++ b/charts/conductor/templates/_helpers.tpl
@@ -55,6 +55,12 @@ app.kubernetes.io/name: {{ include "conductor.name" . }}-watcher
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{- define "conductor.podLabels" -}}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels }}
+{{- end }}
+{{- end }}
+
 {{- define "conductor.watcherLabels" -}}
 helm.sh/chart: {{ include "conductor.chart" . }}
 {{ include "conductor.watcherSelectorLabels" . }}

--- a/charts/conductor/templates/deployment.yaml
+++ b/charts/conductor/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       {{- end }}
       labels:
         {{- include "conductor.selectorLabels" . | nindent 8 }}
+        {{- include "conductor.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/conductor/templates/external-secrets.yaml
+++ b/charts/conductor/templates/external-secrets.yaml
@@ -2,18 +2,26 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
+ name: {{ .Release.Name }}
+ namespace: {{ .Release.Namespace }}
 spec:
-  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
-  secretStoreRef:
-    name: {{ .Values.externalSecrets.parameterStore.name }}
-    kind: {{ .Values.externalSecrets.parameterStore.kind }}
-  target:
-    creationPolicy: 'Owner'
-    name: {{ .Values.externalSecrets.secretName }}
-  dataFrom:
-  - find:
-      name:
-        regexp: {{ .Values.externalSecrets.secretRegex }}
+ refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+ secretStoreRef:
+   name: {{ .Values.externalSecrets.parameterStore.name }}
+   kind: {{ .Values.externalSecrets.parameterStore.kind }}
+ target:
+   creationPolicy: 'Owner'
+   name: {{ .Values.externalSecrets.secretName }}
+ {{- if .Values.externalSecrets.secretRegex }}
+ dataFrom:
+ - find:
+     name:
+       regexp: {{ .Values.externalSecrets.secretRegex }}
+ {{- end }}
+ {{- if and .Values.externalSecrets.remoteRef.key .Values.externalSecrets.remoteRef.secretKey }}
+ data:
+   - secretKey: {{ .Values.externalSecrets.remoteRef.secretKey }}
+     remoteRef:
+       key: {{ .Values.externalSecrets.remoteRef.key }}
+ {{- end }}
 {{- end }}

--- a/charts/conductor/values.yaml
+++ b/charts/conductor/values.yaml
@@ -12,6 +12,9 @@ externalSecrets:
   parameterStore:
     name: "secret-store-parameter-store"
     kind: ClusterSecretStore
+  # remoteRef:
+  #   key: ~
+  #   secretKey: ~
   secretName: ~
   secretRegex: ~
 

--- a/charts/conductor/values.yaml
+++ b/charts/conductor/values.yaml
@@ -12,11 +12,15 @@ externalSecrets:
   parameterStore:
     name: "secret-store-parameter-store"
     kind: ClusterSecretStore
+  # Use remoteRef to fetch secrets from a remote store (e.g. Azure Key Vault/Google Secret Manager)
+  # This isn't compatible with the secretRegex field, please choose one or the other.
   # remoteRef:
   #   key: ~
   #   secretKey: ~
   secretName: ~
-  secretRegex: ~
+  # Use secretRegex to fetch secrets from AWS Parameter Store (SSM)
+  # This isn't compatible with the remoteRef field, please choose one or the other.
+  # secretRegex: ~
 
 serviceMonitors:
   coredb:

--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -5,7 +5,7 @@ use azure_error::AzureError;
 use azure_identity::TokenCredentialOptions;
 use azure_identity::WorkloadIdentityCredential;
 use azure_mgmt_authorization;
-use azure_mgmt_authorization::models::{RoleAssignment, RoleAssignmentProperties};
+use azure_mgmt_authorization::models::RoleAssignmentProperties;
 use azure_mgmt_msi::models::{
     FederatedIdentityCredential, FederatedIdentityCredentialProperties, Identity, TrackedResource,
 };
@@ -28,7 +28,7 @@ pub async fn create_uami(
     region: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<Identity, AzureError> {
-    let resource_group = format!("{resource_group_prefix}-storage-rg");
+    let resource_group = format!("{resource_group_prefix}-instances");
     let msi_client = azure_mgmt_msi::Client::builder(credentials).build()?;
 
     // Set parameters for User Assigned Managed Identity
@@ -83,7 +83,7 @@ pub async fn get_storage_account_id(
     storage_account_name: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<String, AzureError> {
-    let resource_group = format!("{resource_group_prefix}-storage-rg");
+    let resource_group = format!("{resource_group_prefix}-instances");
     let storage_client = azure_mgmt_storage::Client::builder(credentials).build()?;
     let storage_account_list = storage_client
         .storage_accounts_client()
@@ -153,7 +153,7 @@ pub async fn create_role_assignment(
     uami_principal_id: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<(), AzureError> {
-    let resource_group = format!("{resource_group_prefix}-storage-rg");
+    let resource_group = format!("{resource_group_prefix}-instances");
     let role_assignment_name = uuid::Uuid::new_v4().to_string();
     let role_assignment_client =
         azure_mgmt_authorization::Client::builder(credentials.clone()).build()?;
@@ -229,7 +229,7 @@ pub async fn get_cluster_issuer(
     cluster_name: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<String, AzureError> {
-    let resource_group = format!("{resource_group_prefix}-aks-rg");
+    let resource_group = format!("{resource_group_prefix}-clusters");
     let client = reqwest::Client::new();
     let url = format!(
         "https://management.azure.com/subscriptions/{subscription_id}/resourceGroups/{resource_group}/providers/Microsoft.ContainerService/managedClusters/{cluster_name}?api-version=2024-08-01");
@@ -261,13 +261,13 @@ pub async fn create_federated_identity_credentials(
     instance_name: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<(), AzureError> {
-    let resource_group = format!("{resource_group_prefix}-storage-rg");
+    let resource_group = format!("{resource_group_prefix}-instances");
     let uami_name = instance_name;
     let federated_identity_client = azure_mgmt_msi::Client::builder(credentials.clone()).build()?;
     let cluster_issuer = get_cluster_issuer(
         subscription_id,
         &resource_group,
-        &format!("aks-{resource_group_prefix}-aks-data-1"),
+        &format!("aks-{resource_group_prefix}"),
         credentials.clone(),
     )
     .await?;
@@ -304,7 +304,7 @@ pub async fn delete_uami(
     uami_name: &str,
     credentials: Arc<dyn TokenCredential>,
 ) -> Result<(), AzureError> {
-    let resource_group = format!("{resource_group_prefix}-storage-rg");
+    let resource_group = format!("{resource_group_prefix}-instances");
     let msi_client = azure_mgmt_msi::Client::builder(credentials).build()?;
     msi_client
         .user_assigned_identities_client()

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -993,6 +993,7 @@ async fn init_gcp_storage_workload_identity(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn init_azure_storage_workload_identity(
     is_azure: bool,
     read_msg: &Message<CRUDevent>,


### PR DESCRIPTION
* Update conductor helm chart
  * Support external secrets from Azure Key Vault
  * Support adding `podLabels` so that the pod will use Azure Workload Identity
  
* Update conductor code to rename the resource groups where the infrastructure lives.