### PR TITLE
remove whitespace from environment variable

### DIFF
--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -100,7 +100,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
         .parse()
         .expect("error parsing AZURE_SUBSCRIPTION_ID");
     // This is necessary for working with multiple resource groups. Example format: cdb-plat-eus-dev
-    let azure_resource_group_prefix: String = env::var("AZURE_RESOURCE_GROUP_PREFIX ")
+    let azure_resource_group_prefix: String = env::var("AZURE_RESOURCE_GROUP_PREFIX")
         .unwrap_or_else(|_| "".to_owned())
         .parse()
         .expect("error parsing AZURE_RESOURCE_GROUP_PREFIX");


### PR DESCRIPTION
Remove white space from the `AZURE_RESOURCE_GROUP_PREFIX` as it is causing this error

```
[2024-11-21T22:15:08Z INFO  conductor] Starting conductor
[2024-11-21T22:15:08Z INFO  actix_server::builder] starting 1 workers
[2024-11-21T22:15:08Z INFO  actix_server::server] Actix runtime found; starting in Actix runtime
[2024-11-21T22:15:08Z INFO  actix_server::server] starting service: "actix-web-service-0.0.0.0:8080", workers: 1, listening on: 0.0.0.0:8080
thread 'main' panicked at src/main.rs:142:9:
AZURE_STORAGE_ACCOUNT, AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP_PREFIX, and AZURE_REGION must be set if IS_AZURE is true
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
[2024-11-21T22:15:33Z INFO  actix_server::server] SIGTERM received; starting graceful shutdown
[2024-11-21T22:15:33Z INFO  actix_server::worker] graceful worker shutdown; finishing 1 connections
[2024-11-21T22:15:33Z INFO  actix_server::accept] accept thread stopped
```