### PR TITLE
disable snapshots, remove scheduledbackup for snapshots

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "controller"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -901,12 +901,12 @@ async fn init_cloud_perms(
         }),
     };
 
-    // TODO: disable volumesnapshots for now until we can make them work with CNPG
-    // Enable VolumeSnapshots for all instances being created
-    let volume_snapshot = Some(VolumeSnapshot {
-        enabled: false,
-        snapshot_class: None,
-    });
+    // TODO: disable volumesnapshots for now until we can figure out how to not crash the
+    // snapshot-controller due to the amount of snapshots being created/managed
+    // let volume_snapshot = Some(VolumeSnapshot {
+    //     enabled: false,
+    //     snapshot_class: None,
+    // });
 
     let write_path = read_msg
         .message
@@ -922,7 +922,9 @@ async fn init_cloud_perms(
             inherit_from_iam_role: Some(true),
             ..Default::default()
         }),
-        volume_snapshot,
+        // disable volumesnapshots for now until we can figure out how to not crash the
+        // snapshot-controller due to the amount of snapshots being created/managed
+        // volume_snapshot,
         ..Default::default()
     };
 

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -389,9 +389,9 @@ mod tests {
     #[test]
     fn test_is_cluster_hibernated() {
         // Not hibernated yet: still in progress
-        assert_eq!(is_cluster_hibernated(&hibernation_in_progress()), false);
+        assert!(!is_cluster_hibernated(&hibernation_in_progress()));
         // Not hibernated: unrelated condition
-        assert_eq!(is_cluster_hibernated(&backed_up_cluster()), false);
+        assert!(!is_cluster_hibernated(&backed_up_cluster()));
         // Hibernated: "type" is "cnpg.io/hibernation" and "status" is "True"
         assert!(is_cluster_hibernated(&hibernation_completed()));
     }

--- a/tembo-operator/src/config.rs
+++ b/tembo-operator/src/config.rs
@@ -5,7 +5,6 @@ pub struct Config {
     pub enable_backup: bool,
     pub enable_volume_snapshot: bool,
     pub volume_snapshot_retention_period_days: u64,
-    pub reconcile_timestamp_ttl: u64,
     pub reconcile_ttl: u64,
 }
 
@@ -18,14 +17,10 @@ impl Default for Config {
                 .unwrap(),
             volume_snapshot_retention_period_days: from_env_default(
                 "VOLUME_SNAPSHOT_RETENTION_PERIOD_DAYS",
-                "40",
+                "1",
             )
             .parse()
             .unwrap(),
-            // The time to live for recociling the reconcile timestamp
-            reconcile_timestamp_ttl: from_env_default("RECONCILE_TIMESTAMP_TTL", "30")
-                .parse()
-                .unwrap(),
             // The time to live for reconciling the entire instance
             reconcile_ttl: from_env_default("RECONCILE_TTL", "90").parse().unwrap(),
         }

--- a/tembo-operator/src/dedicated_networking.rs
+++ b/tembo-operator/src/dedicated_networking.rs
@@ -419,6 +419,18 @@ async fn reconcile_dedicated_networking_service(
     );
     service_spec.insert("sessionAffinity".to_string(), json!("None"));
     service_spec.insert("type".to_string(), json!(service_type));
+
+    // This variable should be reworked.
+    // For now lets just suppress the warning.
+    // warning: redundant closure
+    //    --> src/dedicated_networking.rs:422:71
+    //     |
+    // 422 |     let ip_allow_list = cdb.spec.ip_allow_list.clone().unwrap_or_else(|| vec![]);
+    //     |                                                                       ^^^^^^^^^ help: replace the closure with `Vec::new`: `std::vec::Vec::new`
+    //     |
+    //     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure
+    //     = note: `#[warn(clippy::redundant_closure)]` on by default
+    #[allow(clippy::redundant_closure)]
     let ip_allow_list = cdb.spec.ip_allow_list.clone().unwrap_or_else(|| vec![]);
 
     // Allow ip_allow_list to allow all entries are in CIDR notation


### PR DESCRIPTION
Currently we have ~ `36000`+ `VolumeSnapshots` on the `us-east-1` cluster in prod.  This is causing the snapshot-controller to crash as it can't currently view that many objects from the Kubernetes API.

```
I1124 19:28:25.790912       1 main.go:157] Version: v8.0.1
I1124 19:28:25.791757       1 main.go:206] Start NewCSISnapshotController with kubeconfig [] resyncPeriod [15m0s]
E1124 19:29:25.797250       1 main.go:93] Failed to list v1 volumesnapshots with error=the server was unable to return a response in the time allotted, but may still be processing the request (get volumesnapshots.snapshot.storage.k8s.io)
E1124 19:30:25.898711       1 main.go:93] Failed to list v1 volumesnapshots with error=the server was unable to return a response in the time allotted, but may still be processing the request (get volumesnapshots.snapshot.storage.k8s.io)
I1124 19:31:26.049852       1 request.go:1110] Stream error http2.StreamError{StreamID:0x5, Code:0x2, Cause:(*errors.errorString)(0x2afa130)} when reading response body, may be caused by closed connection.
E1124 19:31:26.049969       1 main.go:93] Failed to list v1 volumesnapshots with error=stream error when reading response body, may be caused by closed connection. Please retry. Original error: stream error: stream ID 5; INTERNAL_ERROR; received from peer
E1124 19:32:26.276700       1 main.go:93] Failed to list v1 volumesnapshots with error=the server was unable to return a response in the time allotted, but may still be processing the request (get volumesnapshots.snapshot.storage.k8s.io)
E1124 19:33:25.798645       1 main.go:93] Failed to list v1 volumesnapshots with error=Get "[https://172.20.0.1:443/apis/snapshot.storage.k8s.io/v1/volumesnapshots](https://172.20.0.1/apis/snapshot.storage.k8s.io/v1/volumesnapshots)": context deadline exceeded
E1124 19:33:25.798682       1 main.go:231] Exiting due to failure to ensure CRDs exist during startup: context deadline exceeded
```

Disable volume snapshots again and make sure we remove the `ScheduledBackup` along with removing `VolumeSnapshots`

The removal of the `VolumeSnapshots` will be done with the operator (default keeping 1 day).  If every namespace has 40  `VolumeSnapshots` it will remove all but 1, then remove that 24 hours later after it's over 24 hours old.

This adds 2 new functions `remove_scheduled_backup` and `remove_snap_scheduled_backup`.  This will ensure that the `ScheduledBackup` of type `volumeSnapshot` is removed from the namespace of the instance.