### PR TITLE
Remove `IngressRouteTCP` for Stopped Instances

### DIFF
--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -153,7 +153,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         delete_ingress_route_tcp(ingress_route_tcp_api.clone(), &namespace, &prefix_read_only).await
     {
         warn!(
-            "Error deleting ingress route for {}: {}",
+            "Error deleting postgres ingress route for {}: {}",
             cdb.name_any(),
             err
         );
@@ -169,7 +169,7 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
     .await
     {
         warn!(
-            "Error deleting extra ingress route for {}: {}",
+            "Error deleting postgres ingress route for {}: {}",
             cdb.name_any(),
             err
         );
@@ -181,7 +181,19 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         delete_ingress_route_tcp(ingress_route_tcp_api.clone(), &namespace, &prefix_pooler).await
     {
         warn!(
-            "Error deleting pooler ingress route for {}: {}",
+            "Error deleting postgres ingress route for {}: {}",
+            cdb.name_any(),
+            err
+        );
+        return Err(Action::requeue(Duration::from_secs(300)));
+    }
+
+    let prefix_extra = format!("extra-{}-rw", cdb.name_any().as_str());
+    if let Err(err) =
+        delete_ingress_route_tcp(ingress_route_tcp_api.clone(), &namespace, &prefix_extra).await
+    {
+        warn!(
+            "Error deleting extra postgres ingress route for {}: {}",
             cdb.name_any(),
             err
         );

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -148,12 +148,10 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
 
     // Remove IngressRouteTCP route for stopped instances
     let ingress_route_tcp_name = format!("{}-ro-0", cdb.name_any().as_str());
-    if let Err(err) = delete_ingress_route_tcp(
-        Api::namespaced(client, &namespace),
-        &namespace,
-        &ingress_route_tcp_name,
-    )
-    .await
+    let ingress_route_tcp_api = Api::namespaced(ctx.client.clone(), &namespace);
+
+    if let Err(err) =
+        delete_ingress_route_tcp(ingress_route_tcp_api, &namespace, &ingress_route_tcp_name).await
     {
         warn!(
             "Error deleting ingress route for {}: {}",

--- a/tembo-operator/src/cloudnativepg/hibernate.rs
+++ b/tembo-operator/src/cloudnativepg/hibernate.rs
@@ -146,11 +146,12 @@ pub async fn reconcile_cluster_hibernation(cdb: &CoreDB, ctx: &Arc<Context>) -> 
         }
     }
 
-    // Delete the IngressRouteTCP route for hibernated instances
+    // Remove IngressRouteTCP route for stopped instances
+    let ingress_route_tcp_name = format!("{}-ro-0", cdb.name_any().as_str());
     if let Err(err) = delete_ingress_route_tcp(
         Api::namespaced(client, &namespace),
         &namespace,
-        &format!("{}-ro-0", cdb.name_any().as_str()),
+        &ingress_route_tcp_name,
     )
     .await
     {

--- a/tembo-operator/src/ingress.rs
+++ b/tembo-operator/src/ingress.rs
@@ -196,7 +196,7 @@ async fn apply_ingress_route_tcp(
     Ok(())
 }
 
-async fn delete_ingress_route_tcp(
+pub async fn delete_ingress_route_tcp(
     ingress_route_tcp_api: Api<IngressRouteTCP>,
     namespace: &str,
     ingress_route_tcp_name: &String,

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -5808,6 +5808,7 @@ CREATE EVENT TRIGGER pgrst_watch
         let test = TestCore::new(test_name).await;
         let name = test.name.clone();
         let pooler_name = format!("{}-pooler", name);
+        let namespace = test.namespace.clone();
 
         // Generate very simple CoreDB JSON definitions. The first will be for
         // initializing and starting the cluster, and the second for stopping
@@ -5849,6 +5850,19 @@ CREATE EVENT TRIGGER pgrst_watch
         assert!(pooler_status_running(&test.poolers, &pooler_name)
             .await
             .not());
+
+        // Assert that ingress routes are removed after hibernation
+
+        let client = test.client.clone();
+        let ingresses_tcp: Vec<IngressRouteTCP> =
+            list_resources(client.clone(), &name, &namespace, 0)
+                .await
+                .unwrap();
+        assert_eq!(
+            ingresses_tcp.len(),
+            0,
+            "Ingress routes should be removed after hibernation"
+        );
 
         // Patch the cluster to start it up again, then check to ensure it
         // actually did so. This proves hibernation can be reversed.


### PR DESCRIPTION
https://linear.app/tembo/issue/TEM-2241/%5Btembo-operator%5D-when-paused-we-should-remove-the-ingressroutetcp-for