### PR TITLE
Specify Principal Type in Rle Assignment Properties

### DIFF
--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -5,6 +5,7 @@ use azure_error::AzureError;
 use azure_identity::TokenCredentialOptions;
 use azure_identity::WorkloadIdentityCredential;
 use azure_mgmt_authorization;
+use azure_mgmt_authorization::models::role_assignment_properties::PrincipalType;
 use azure_mgmt_authorization::models::RoleAssignmentProperties;
 use azure_mgmt_msi::models::{
     FederatedIdentityCredential, FederatedIdentityCredentialProperties, Identity, TrackedResource,
@@ -196,7 +197,7 @@ pub async fn create_role_assignment(
             scope: None,
             role_definition_id: role_definition,
             principal_id: uami_principal_id.to_string(),
-            principal_type: None,
+            principal_type: Some(PrincipalType::ServicePrincipal),
             description: None,
             condition: None,
             condition_version: None,


### PR DESCRIPTION
When creating a new role assignment for a UAMI, we're seeing a failure that could be caused by 'replication delay'. Azure SDK error logs suggest we should provide the principal type for the role assignment:

`Check that you have the correct principal ID. If you are creating this principal and then immediately assigning a role, this error might be related to a replication delay. In this case, set the role assignment principalType property to a value, such as ServicePrincipal, User, or Group.`

Set the principal type to `ServicePrincipal` to see if this resolves the issue.