### PR TITLE
Fix Azure Restore Path

### DIFF
--- a/conductor/src/cloud.rs
+++ b/conductor/src/cloud.rs
@@ -68,6 +68,17 @@ impl CloudProvider {
         }
     }
 
+    // If azure, generate storage_account_url
+    pub fn storage_account_url(&self, azure_storage_account: Option<&str>) -> String {
+        match self {
+            CloudProvider::Azure => format!(
+                "{}.blob.core.windows.net/",
+                azure_storage_account.unwrap_or("")
+            ),
+            _ => "".to_string(),
+        }
+    }
+
     pub fn builder() -> CloudProviderBuilder {
         CloudProviderBuilder::new()
     }

--- a/conductor/src/cloud.rs
+++ b/conductor/src/cloud.rs
@@ -68,7 +68,7 @@ impl CloudProvider {
         }
     }
 
-    // If azure, generate storage_account_url
+    // If azure, generate storage_account_url for Azure restore scenarios
     pub fn storage_account_url(&self, azure_storage_account: Option<&str>) -> String {
         match self {
             CloudProvider::Azure => format!(

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -914,9 +914,10 @@ mod tests {
             &spec,
             &cloud_provider,
         )
-            .await
-            .expect("Failed to generate spec");
-        let expected_backups_path = "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
+        .await
+        .expect("Failed to generate spec");
+        let expected_backups_path =
+            "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
         assert_eq!(
             result["spec"]["restore"]["backupsPath"].as_str().unwrap(),
             expected_backups_path
@@ -943,9 +944,10 @@ mod tests {
             &spec,
             &cloud_provider,
         )
-            .await
-            .expect("Failed to generate spec");
-        let expected_backups_path = "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
+        .await
+        .expect("Failed to generate spec");
+        let expected_backups_path =
+            "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
         assert_eq!(
             result["spec"]["restore"]["backupsPath"].as_str().unwrap(),
             expected_backups_path

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -892,4 +892,63 @@ mod tests {
             expected_backups_path
         );
     }
+
+    // These should fail until we include the azure storage account in the backups path
+    #[tokio::test]
+    async fn test_generate_spec_with_non_matching_azure_bucket() {
+        let spec = CoreDBSpec {
+            restore: Some(Restore {
+                backups_path: Some("https://v2/test-instance".to_string()),
+                ..Restore::default()
+            }),
+            ..CoreDBSpec::default()
+        };
+        let cloud_provider = CloudProvider::Azure;
+        let result = generate_spec(
+            "org-id",
+            "entity-name",
+            "instance-id",
+            "azure_data_1_eus1",
+            "namespace",
+            "my-blob",
+            &spec,
+            &cloud_provider,
+        )
+            .await
+            .expect("Failed to generate spec");
+        let expected_backups_path = "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
+        assert_eq!(
+            result["spec"]["restore"]["backupsPath"].as_str().unwrap(),
+            expected_backups_path
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_spec_with_azure_bucket() {
+        let spec = CoreDBSpec {
+            restore: Some(Restore {
+                backups_path: Some("https://my-blob/v2/test-instance".to_string()),
+                ..Restore::default()
+            }),
+            ..CoreDBSpec::default()
+        };
+        let cloud_provider = CloudProvider::Azure;
+        let result = generate_spec(
+            "org-id",
+            "entity-name",
+            "instance-id",
+            "azure_data_1_eus1",
+            "namespace",
+            "my-blob",
+            &spec,
+            &cloud_provider,
+        )
+            .await
+            .expect("Failed to generate spec");
+        let expected_backups_path = "https://eusdevsg.blob.core.windows.net/my-blob/v2/test-instance";
+        assert_eq!(
+            result["spec"]["restore"]["backupsPath"].as_str().unwrap(),
+            expected_backups_path
+        );
+    }
 }

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -189,7 +189,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
 
     loop {
         // Read from queue (check for new message)
-        // messages that dont fit a CRUDevent will error
+        // messages that don't fit a CRUDevent will error
         // set visibility timeout to 90 seconds
         let read_msg = queue
             .read::<CRUDevent>(&control_plane_events_queue, 90_i32)
@@ -411,6 +411,12 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     &mut coredb_spec,
                 );
 
+                // If azure, use azure_storage_account. Else None
+                let azure_storage_account = match cloud_provider {
+                    CloudProvider::Azure => Some(azure_storage_account.as_str()),
+                    _ => None,
+                };
+
                 let spec = generate_spec(
                     org_id,
                     &stack_type,
@@ -418,6 +424,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     &read_msg.message.data_plane_id,
                     &namespace,
                     &backup_archive_bucket,
+                    azure_storage_account,
                     &coredb_spec,
                     &cloud_provider,
                 )

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -411,7 +411,8 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     &mut coredb_spec,
                 );
 
-                // If azure, use azure_storage_account. Else None
+                // If cloud provider is Azure, we need to pass the storage account name to generate_spec
+                // so that the storage account URL can be generated for Azure restore scenarios
                 let azure_storage_account = match cloud_provider {
                     CloudProvider::Azure => Some(azure_storage_account.as_str()),
                     _ => None,


### PR DESCRIPTION
Azure restores need additional info in their `backupsPath` value. 

The current format looks like:
`https://cdb-plat-eus-dev-data-1-instance-backups/v2/untidily-noteworthy-coral`

The format should instead look like: 
`https://<storage-account-name>.blob.core.windows.net/cdb-plat-eus-dev-data-1-instance-backups/v2/untidily-noteworthy-coral`

This PR properly formats the `backupsPath` value for Azure restores.