### PR TITLE
Only reconcile ing tcp for apps with tcp route

### DIFF
--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -1010,37 +1010,29 @@ pub async fn reconcile_app_services(
         for appsvc in appsvcs.iter() {
             let app_name = appsvc.name.clone();
 
-            // Only reconcile IngressRouteTCP if the AppService has a TCP route
-            if appsvc.routing.is_some() {
-                for route in appsvc.routing.as_ref().unwrap() {
-                    if route.ingress_type == Some(IngressType::tcp) {
-                        match reconcile_ingress_tcp(
-                            client.clone(),
-                            &coredb_name,
-                            &ns,
-                            oref.clone(),
-                            desired_tcp_routes.clone(),
-                            vec![],
-                            desired_entry_points_tcp.clone(),
-                            &app_name,
-                        )
-                        .await
-                        {
-                            Ok(_) => {
-                                debug!(
-                                    "Updated/applied IngressRouteTCP for {}.{}",
-                                    ns, coredb_name,
-                                );
-                            }
-                            Err(e) => {
-                                error!(
-                                    "Failed to update/apply IngressRouteTCP {}.{}: {}",
-                                    ns, coredb_name, e
-                                );
-                                has_errors = true;
-                            }
-                        }
-                    }
+            match reconcile_ingress_tcp(
+                client.clone(),
+                &coredb_name,
+                &ns,
+                oref.clone(),
+                desired_tcp_routes.clone(),
+                // TODO: fill with actual MiddlewareTCPs when it is supported
+                // first supported MiddlewareTCP will be for custom domains
+                vec![],
+                desired_entry_points_tcp.clone(),
+                &app_name,
+            )
+            .await
+            {
+                Ok(_) => {
+                    debug!("Updated/applied IngressRouteTCP for {}.{}", ns, coredb_name,);
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to update/apply IngressRouteTCP {}.{}: {}",
+                        ns, coredb_name, e
+                    );
+                    has_errors = true;
                 }
             }
         }

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -6077,16 +6077,14 @@ CREATE EVENT TRIGGER pgrst_watch
         assert_eq!(pods_list.items.len(), 0);
 
         // Assert that IngressRouteTCPs are removed after hibernation
-        // TODO(ianstanton) Typically there should be 0 here, but we're creating one for postgrest
-        //  due to a bug. This should be updated to 0 after the bug is fixed.
         let client = test.client.clone();
         let ingresses_tcp: Vec<IngressRouteTCP> =
-            list_resources(client.clone(), &name, &namespace, &default_params, 1)
+            list_resources(client.clone(), &name, &namespace, &default_params, 0)
                 .await
                 .unwrap();
         assert_eq!(
             ingresses_tcp.len(),
-            1,
+            0,
             "IngressRouteTCPs should be removed after hibernation"
         );
 
@@ -6115,17 +6113,15 @@ CREATE EVENT TRIGGER pgrst_watch
         let pods_list = pods.list(&Default::default()).await.unwrap();
         assert_eq!(pods_list.items.len(), 4);
 
-        // Assert there are 4 IngressRouteTCPs created after starting. One for postgres, pooler,
-        // ferretdb and postgrest
-        // TODO(ianstanton) postgrest's IngressRouteTCP is being created due to a bug. This should
-        //  check for 3 IngressRouteTCPs after the bug is fixed.
+        // Assert there are 3 IngressRouteTCPs created after starting. One for postgres, pooler,
+        // ferretdb
         let ingress_tcps: Vec<IngressRouteTCP> =
-            list_resources(client.clone(), &name, &namespace, &default_params, 4)
+            list_resources(client.clone(), &name, &namespace, &default_params, 3)
                 .await
                 .unwrap();
         assert_eq!(
             ingress_tcps.len(),
-            4,
+            3,
             "IngressRouteTCPs should be created after starting"
         );
 

--- a/tembo-operator/tests/integration_tests.rs
+++ b/tembo-operator/tests/integration_tests.rs
@@ -6062,6 +6062,19 @@ CREATE EVENT TRIGGER pgrst_watch
         let pods_list = pods.list(&Default::default()).await.unwrap();
         assert_eq!(pods_list.items.len(), 4);
 
+        // Assert there are 3 IngressRouteTCPs created after starting. One for postgres, pooler,
+        // ferretdb
+        let client = test.client.clone();
+        let ingresses_tcp: Vec<IngressRouteTCP> =
+            list_resources(client.clone(), &name, &namespace, &default_params, 3)
+                .await
+                .unwrap();
+        assert_eq!(
+            ingresses_tcp.len(),
+            3,
+            "IngressRouteTCPs should be created after starting"
+        );
+
         // Stop the cluster and check to make sure it's not running to ensure
         // hibernate is doing its job.
 


### PR DESCRIPTION
- Fix bug `reconcile_ingress_tcp` in app services. If _any_ app service had a route with `"ingressType": "tcp"`, we would create `IngressRouteTCP` resources for _all_ app services in the spec.
  - Example: The follwoing `appServices` definition would create an `IngressRouteTCP` for both `fdb-api` _and_ `postgrest`. 
  - We would expect it to only create one for `fdb-api` because it has a route with `"ingressType": "tcp"`, but we should not create one for `postgrest`
  ```
  "appServices": [
                    {
                        "name": "postgrest",
                        "image": "postgrest/postgrest:v10.0.0",
                        "routing": [
                            {
                                "port": 3000,
                                "ingressPath": "/",
                                "ingressType": "http"
                            }
                        ],
                        ...
                    },
                    {
                        "name": "fdb-api",
                        "image": "ghcr.io/ferretdb/ferretdb",
                        "routing": [
                            {
                                "port": 27018,
                                "ingressPath": "/ferretdb/v1",
                                "entryPoints": [
                                    "ferretdb"
                                ],
                                "ingressType": "tcp"
                            }
                        ],
                        ...
                 ]
  ```