### PR TITLE
Update olap stack extensions

### DIFF
--- a/tembo-stacks/src/stacks/specs/olap.yaml
+++ b/tembo-stacks/src/stacks/specs/olap.yaml
@@ -31,17 +31,17 @@ postgres_config:
     value: logical
 trunk_installs:
   - name: pg_stat_statements
-    version: 1.10.0
+    version: 1.11.0
   - name: hydra_columnar
     version: 1.1.1
   - name: pg_partman
-    version: 5.0.1
+    version: 5.2.4
   - name: pg_cron
-    version: 1.6.2
+    version: 1.6.4
   - name: postgres_fdw
     version: 1.1.0
   - name: clerk_fdw
-    version: 0.2.4
+    version: 0.3.2
   - name: parquet_s3_fdw
     version: 1.1.0
   - name: pg_tier 
@@ -51,7 +51,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 1.10.0
+        version: 1.11.0
   - name: columnar
     locations:
       - database: postgres
@@ -61,13 +61,13 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 5.0.1
+        version: 5.2.4
   - name: pg_cron
     description: pg_cron
     locations:
     - database: postgres
       enabled: true
-      version: 1.6.2
+      version: 1.6.4
   - name: postgres_fdw
     description: postgres_fdw
     locations:
@@ -79,7 +79,7 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version:  0.2.4
+      version:  0.3.2
   - name: parquet_s3_fdw
     description: parquet_s3_fdw
     locations:


### PR DESCRIPTION
Necessary to support Postgres 17, though it cannot be used until pg_tier is updated.