### PR TITLE
Update timeseries stack extensions

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.23.8"
+version = "0.23.9"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/timeseries.yaml
+++ b/tembo-stacks/src/stacks/specs/timeseries.yaml
@@ -6,7 +6,6 @@ images:
   14: "standard-cnpg:14-35b0240"
   15: "standard-cnpg:15-35b0240"
   16: "standard-cnpg:16-35b0240"
-  17: "standard-cnpg:17-35b0240"
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:
@@ -30,17 +29,17 @@ postgres_config:
     value: logical
 trunk_installs:
   - name: pg_timeseries
-    version: 0.1.6
+    version: 0.1.7
   - name: hydra_columnar
     version: 1.1.1
   - name: pg_cron
-    version: 1.6.2
+    version: 1.6.4
   - name: tembo_ivm
     version: 1.9.1
   - name: pg_partman
-    version: 5.0.1
+    version: 5.2.4
   - name: pg_stat_statements
-    version: 1.10.0
+    version: 1.11.0
   - name: parquet_s3_fdw
     version: 1.1.0
   - name: pg_tier
@@ -55,13 +54,13 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 5.0.1
+        version: 5.2.4
   - name: pg_cron
     description: pg_cron
     locations:
       - database: postgres
         enabled: true
-        version: 1.6.2
+        version: 1.6.4
   - name: pg_ivm
     description: pg_ivm
     locations:
@@ -77,7 +76,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 1.10.0
+        version: 1.11.0
   - name: parquet_s3_fdw
     locations:
       - database: postgres


### PR DESCRIPTION
Necessary to support Postgres 17, though it cannot be used until pg_tier and columnar are updated. Therefore remove the Postgres 17 config, which has yet to work.

Increment tembo-stacks to v0.23.9.

Completes tem-2693.