### PR TITLE
Drop Read Condition from Azure Role Assignment

### DIFF
--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -173,18 +173,6 @@ pub async fn create_role_assignment(
         "\
 (
     (
-        !(ActionMatches{{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'}})
-    )
-    OR 
-    (
-        @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals '{azure_backup_container}'
-        AND
-        @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike '{namespace}/*'
-    )
-)
-AND
-(
-    (
         !(ActionMatches{{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write'}})
         AND
         !(ActionMatches{{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action'}})


### PR DESCRIPTION
Drop read condition to allow for working Azure backups with write condition.