### PR TITLE
Only Allow for Writing in Instance Blob

### DIFF
--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -180,6 +180,8 @@ pub async fn create_role_assignment(
     OR
     (
         @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals '{azure_backup_container}'
+        AND
+        @Resource[Microsoft.Storage/storageAccounts/blobServices/containers/blobs:path] StringLike '{namespace}/*'
     )
 )
     "


### PR DESCRIPTION
Current role assignment conditions allow for writing to any blob in the container. Scope writes to the instance's blob.