### PR TITLE
pin pgmq

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1102,11 +1102,11 @@ checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "controller"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "actix-web",
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "itertools",
@@ -1115,6 +1115,7 @@ dependencies = [
  "lazy_static",
  "opentelemetry 0.19.0",
  "passwords",
+ "percent-encoding",
  "prometheus",
  "rand 0.8.5",
  "regex",

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -16,7 +16,7 @@ env_logger = "0.10.0"
 futures = "0.3.28"
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"] }
 log = "0.4.17"
-pgmq = "0.29.2"
+pgmq = "=0.29.2"
 schemars = "0.8.12"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"


### PR DESCRIPTION
Apparently we need to pin the version of the pgmq crate to `0.29.2` exactly even though we have the version set, it somehow still will use `0.29.4` during the build process.  

Using the latest version causes an error in Conductor:

```
[2025-01-02T23:10:07Z DEBUG sqlx::query] summary="SELECT * from pgmq.read(queue_name=>$1::text, …" db.statement="\n\nSELECT\n  *\nfrom\n  pgmq.read(\n    queue_name = > $1 :: text,\n    vt = > $2 :: integer,\n    qty = > $3 :: integer\n  )\n" rows_affected=0 rows_returned=1 elapsed=6.350657ms elapsed_secs=0.006350657
[2025-01-02T23:10:07Z ERROR conductor] error in conductor: PgmqError(DatabaseError(ColumnIndexOutOfBounds { index: 5, len: 5 }))
```