### PR TITLE
Correct the secret name where the URL encoded connection string is located

### DIFF
--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.54.0"
+version = "0.54.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.54.0"
+version = "0.54.1"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -465,6 +465,7 @@ fn generate_deployment(
 
     // set any user provided env vars last
     // including the valueFromX values
+    let encoded_connection_secret_name = format!("{}-connection", coredb_name);
     if let Some(envs) = appsvc.env.clone() {
         for env in envs {
             let evar: Option<EnvVar> = match (env.value, env.value_from_platform) {
@@ -482,11 +483,18 @@ fn generate_deployment(
                         EnvVarRef::EncodedReadOnlyConnection => "encoded_ro_uri",
                         EnvVarRef::EncodedReadWriteConnection => "encoded_rw_uri",
                     };
+                    let secret_name = match e {
+                        EnvVarRef::EncodedReadOnlyConnection
+                        | EnvVarRef::EncodedReadWriteConnection => {
+                            encoded_connection_secret_name.clone()
+                        }
+                        _ => apps_connection_secret_name.clone(),
+                    };
                     Some(EnvVar {
                         name: env.name,
                         value_from: Some(EnvVarSource {
                             secret_key_ref: Some(SecretKeySelector {
-                                name: Some(apps_connection_secret_name.clone()),
+                                name: Some(secret_name),
                                 key: secret_key.to_string(),
                                 ..SecretKeySelector::default()
                             }),


### PR DESCRIPTION
With the #1114 change, the name of the kubernetes secret is wrong where the URL encoded connection string lives. 

This PR fixes the location of the secret.