### PR TITLE
refactor how and where we set the encoded connection string

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "controller"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "controller"
-version = "0.54.0"
+version = "0.54.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.lock
+++ b/tembo-operator/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.54.1"
+version = "0.54.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/tembo-operator/Cargo.toml
+++ b/tembo-operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "controller"
 description = "Tembo Operator for Postgres"
-version = "0.54.1"
+version = "0.54.2"
 edition = "2021"
 default-run = "controller"
 license = "Apache-2.0"

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -1051,13 +1051,6 @@ pub async fn prepare_apps_connection_secret(client: Client, cdb: &CoreDB) -> Res
     let secret_name = format!("{}-connection", cdb_name);
     let new_secret_name = format!("{}-apps", cdb_name);
 
-    // Add labels to the secret to identify who is the owner
-    let mut labels: BTreeMap<String, String> = BTreeMap::new();
-    labels.insert("app".to_owned(), "coredb".to_string());
-    labels.insert("coredb.io/name".to_owned(), cdb.name_any());
-    labels.insert("coredb.io/owner".to_owned(), "tembo-operator".to_string());
-    labels.insert("coredb.io/secret".to_owned(), "apps".to_string());
-
     let secrets_api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
 
     // Fetch the original secret
@@ -1088,7 +1081,6 @@ pub async fn prepare_apps_connection_secret(client: Client, cdb: &CoreDB) -> Res
         metadata: kube::api::ObjectMeta {
             name: Some(new_secret_name.to_string()),
             namespace: Some(namespace.to_string()),
-            labels: Some(labels.clone()),
             ..Default::default()
         },
         ..Default::default()

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -1056,6 +1056,7 @@ pub async fn prepare_apps_connection_secret(client: Client, cdb: &CoreDB) -> Res
     labels.insert("app".to_owned(), "coredb".to_string());
     labels.insert("coredb.io/name".to_owned(), cdb.name_any());
     labels.insert("coredb.io/owner".to_owned(), "tembo-operator".to_string());
+    labels.insert("coredb.io/secret".to_owned(), "apps".to_string());
 
     let secrets_api: Api<Secret> = Api::namespaced(client.clone(), &namespace);
 

--- a/tembo-operator/src/secret.rs
+++ b/tembo-operator/src/secret.rs
@@ -29,17 +29,10 @@ pub async fn reconcile_secret(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Act
     let oref = cdb.controller_owner_ref(&()).unwrap();
     labels.insert("app".to_owned(), "coredb".to_string());
     labels.insert("coredb.io/name".to_owned(), cdb.name_any());
-    labels.insert("coredb.io/owner".to_owned(), "tembo-operator".to_string());
-    labels.insert("coredb.io/secret".to_owned(), "connection".to_string());
 
     // check for existing secret
-    let lp = ListParams::default().labels(
-        format!(
-            "app=coredb,coredb.io/name={},coredb.io/owner=tembo-operator,coredb.io/secret=connection",
-            cdb.name_any()
-        )
-        .as_str(),
-    );
+    let lp = ListParams::default()
+        .labels(format!("app=coredb,coredb.io/name={}", cdb.name_any()).as_str());
     let secrets = match secret_api.list(&lp).await {
         Ok(secrets) => secrets,
         Err(e) => {

--- a/tembo-operator/src/secret.rs
+++ b/tembo-operator/src/secret.rs
@@ -29,10 +29,17 @@ pub async fn reconcile_secret(cdb: &CoreDB, ctx: Arc<Context>) -> Result<(), Act
     let oref = cdb.controller_owner_ref(&()).unwrap();
     labels.insert("app".to_owned(), "coredb".to_string());
     labels.insert("coredb.io/name".to_owned(), cdb.name_any());
+    labels.insert("coredb.io/owner".to_owned(), "tembo-operator".to_string());
+    labels.insert("coredb.io/secret".to_owned(), "connection".to_string());
 
     // check for existing secret
-    let lp = ListParams::default()
-        .labels(format!("app=coredb,coredb.io/name={}", cdb.name_any()).as_str());
+    let lp = ListParams::default().labels(
+        format!(
+            "app=coredb,coredb.io/name={},coredb.io/owner=tembo-operator,coredb.io/secret=connection",
+            cdb.name_any()
+        )
+        .as_str(),
+    );
     let secrets = match secret_api.list(&lp).await {
         Ok(secrets) => secrets,
         Err(e) => {


### PR DESCRIPTION
This PR fixes where the secret is read from.  The sqlrunner is looking at the secrets from `<namespace>-apps` and that sets the connection string from `<namespace>-connection`.  This makes sure that the `encoded_rw_uri` is copied correctly.