### PR TITLE
Upgrade to the latest geo-cnpg image

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.23.9"
+version = "0.23.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.23.9"
+version = "0.23.10"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/gis.yaml
+++ b/tembo-stacks/src/stacks/specs/gis.yaml
@@ -3,10 +3,10 @@ description: Postgres for geospatial workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "geo-cnpg:14-35b0240"
-  15: "geo-cnpg:15-35b0240"
-  16: "geo-cnpg:16-35b0240"
-  17: "geo-cnpg:17-35b0240"
+  14: "geo-cnpg:14-b808885"
+  15: "geo-cnpg:15-b808885"
+  16: "geo-cnpg:16-b808885"
+  17: "geo-cnpg:17-b808885"
 stack_version: 0.1.0
 postgres_config_engine: standard
 postgres_config:


### PR DESCRIPTION
Includes PostGIS 3.5.0 and the latest MobilityDB. Completes tem-2688.