### PR TITLE
Update the ML Stack extensions

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.23.10"
+version = "0.23.11"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/machine_learning.yaml
+++ b/tembo-stacks/src/stacks/specs/machine_learning.yaml
@@ -3,9 +3,10 @@ description: A Postgres instance equipped with machine learning extensions and o
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  15: "ml-cnpg:15-5120dd1"
-  16: "ml-cnpg:16-5120dd1"
-stack_version: 0.3.0
+  15: "ml-cnpg:15-8eb6833"
+  16: "ml-cnpg:16-8eb6833"
+  17: "ml-cnpg:17-8eb6833"
+stack_version: 0.4.0
 compute_constraints:
   min:
     cpu: 2
@@ -26,39 +27,39 @@ postgres_config:
     value: postgresql:///postgres?host=/controller/run
 trunk_installs:
   - name: pgvector
-    version: 0.7.4
+    version: 0.8.0
   - name: postgresml
-    version: 2.7.1
+    version: 2.10.0
   - name: pg_cron
-    version: 1.6.2
+    version: 1.6.4
   - name: pgmq
     version: 1.5.0
   - name: vectorize
-    version: 0.18.2
+    version: 0.20.0
   - name: pg_later
-    version: 0.1.0
+    version: 0.3.0
   - name: plpython3u
     version: 1.0.0
   - name: vectorscale
-    version: 0.3.0
+    version: 0.5.1
 extensions:
   # trunk project pg_vector
   - name: vector
     locations:
       - database: postgres
         enabled: true
-        version: 0.7.4
+        version: 0.8.0
   # trunk project postgresml
   - name: pgml
     locations:
       - database: postgres
         enabled: true
-        version: 2.7.1
+        version: 2.10.0
   - name: pg_cron
     locations:
     - database: postgres
       enabled: true
-      version: 1.6.2
+      version: 1.6.4
   - name: pgmq
     locations:
     - database: postgres
@@ -68,12 +69,12 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 0.18.2
+      version: 0.20.0
   - name: pg_later
     locations:
     - database: postgres
       enabled: true
-      version: 0.1.1
+      version: 0.3.0
   - name: plpython3u
     locations:
     - database: postgres
@@ -83,4 +84,4 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.3.0
+        version: 0.5.1


### PR DESCRIPTION
Including PostgresML v2.10.0, which now supports Postgres 17, so add a config for 17 and update the image to a tag that includes the updated Python libraries it depends on. Completes tem-2725.