### PR TITLE
Increment tembo-stacks to 0.23.14

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.23.13"
+version = "0.23.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.23.13"
+version = "0.23.14"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
* Upgrades all stacks to use the latest version of standard-cnpg
* Builds a specific version of FerretDB into the Mongo stack
