### PR TITLE
Restore pg_analytics 0.2.3

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.23.15"
+version = "0.23.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.23.15"
+version = "0.23.16"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/analytics.yaml
+++ b/tembo-stacks/src/stacks/specs/analytics.yaml
@@ -41,7 +41,7 @@ trunk_installs:
   - name: pg_later
     version: 0.3.0
   - name: pg_analytics
-    version: 0.3.0
+    version: 0.2.3
   - name: pg_parquet
     version: 0.2.0
   - name: postgres_fdw
@@ -98,7 +98,7 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 0.3.0
+      version: 0.2.3
   - name: pg_parquet
     description: pg_parquet
     locations:

--- a/tembo-stacks/src/stacks/specs/paradedb.yaml
+++ b/tembo-stacks/src/stacks/specs/paradedb.yaml
@@ -32,7 +32,7 @@ trunk_installs:
   - name: pg_stat_statements
     version: 1.11.0
   - name: pg_analytics
-    version: 0.3.0
+    version: 0.2.3
   - name: pg_search
     version: 0.14.1
   - name: pg_cron
@@ -67,7 +67,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.3.0
+        version: 0.2.3
   - name: pg_ivm
     locations:
       - database: postgres


### PR DESCRIPTION
v0.3.0 tries to create files on the file system, which fails in our read-only containers. v0.2.3 does not appear to exhibit the same pattern. Follow paradedb/pg_analytics#198 for potential fixes.