### PR TITLE
Upgrade pg_analytics to 0.3.1

### DIFF
--- a/.github/workflows/tembo_release.yml
+++ b/.github/workflows/tembo_release.yml
@@ -52,7 +52,7 @@ jobs:
           - target: x86_64-unknown-linux-musl
             asset_name: x86_64-linux
             os: ubuntu-20.04
-            container: quay.io/tembo/muslrust:1.76.0-stable
+            container: quay.io/tembo/muslrust:1.82.0-stable
             executable: tembo
           - target: aarch64-unknown-linux-musl
             asset_name: aarch64-linux

--- a/tembo-cli/Cargo.lock
+++ b/tembo-cli/Cargo.lock
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-cli"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "actix-cors",
  "actix-service",

--- a/tembo-cli/Cargo.toml
+++ b/tembo-cli/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["temboclient", "tembodataclient"] }
 [package]
 name = "tembo-cli"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 authors = ["Tembo.io"]
 description = "The CLI for Tembo"

--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/analytics.yaml
+++ b/tembo-stacks/src/stacks/specs/analytics.yaml
@@ -41,7 +41,7 @@ trunk_installs:
   - name: pg_later
     version: 0.3.0
   - name: pg_analytics
-    version: 0.2.3
+    version: 0.3.1
   - name: pg_parquet
     version: 0.2.0
   - name: postgres_fdw
@@ -98,7 +98,7 @@ extensions:
     locations:
     - database: postgres
       enabled: true
-      version: 0.2.3
+      version: 0.3.1
   - name: pg_parquet
     description: pg_parquet
     locations:

--- a/tembo-stacks/src/stacks/specs/paradedb.yaml
+++ b/tembo-stacks/src/stacks/specs/paradedb.yaml
@@ -32,7 +32,7 @@ trunk_installs:
   - name: pg_stat_statements
     version: 1.11.0
   - name: pg_analytics
-    version: 0.2.3
+    version: 0.3.1
   - name: pg_search
     version: 0.14.1
   - name: pg_cron
@@ -67,7 +67,7 @@ extensions:
     locations:
       - database: postgres
         enabled: true
-        version: 0.2.3
+        version: 0.3.1
   - name: pg_ivm
     locations:
       - database: postgres


### PR DESCRIPTION
Also build tembo-cli for `x86_64-unknown-linux-musl` with Rust 1.82; it was failing with 1.76 due to an updated version in `Cargo.lock`. Increment the tembo-cli version to trigger a new release.