### PR TITLE
Set correct AKS storageClass for Azure workloads

### DIFF
--- a/conductor/src/azure/uami_builder.rs
+++ b/conductor/src/azure/uami_builder.rs
@@ -12,7 +12,6 @@ use azure_mgmt_msi::models::{
 };
 use futures::StreamExt;
 use log::info;
-use std::fmt::format;
 use std::sync::Arc;
 
 // Get credentials from workload identity
@@ -289,7 +288,7 @@ pub async fn create_federated_identity_credentials(
     let federated_identity_client = azure_mgmt_msi::Client::builder(credentials.clone()).build()?;
     let cluster_issuer = get_cluster_issuer(
         subscription_id,
-        &resource_group_prefix,
+        resource_group_prefix,
         &format!("aks-{resource_group_prefix}"),
         credentials.clone(),
     )

--- a/conductor/src/cloud.rs
+++ b/conductor/src/cloud.rs
@@ -42,6 +42,7 @@ impl CloudProviderBuilder {
     }
 }
 
+#[derive(PartialEq)]
 pub enum CloudProvider {
     AWS,
     Azure,

--- a/conductor/src/gcp/bucket_manager.rs
+++ b/conductor/src/gcp/bucket_manager.rs
@@ -267,7 +267,6 @@ impl BucketIamManager {
     /// # Returns
     ///
     /// Returns a `Condition` instance for the specified bucket.
-
     fn create_bucket_condition(&self, bucket_name: &str, instance_name: &str) -> Condition {
         Condition {
             title: "allow-bucket-and-path".to_string(),

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -982,7 +982,7 @@ mod tests {
         // Test Azure cloud provider
         let spec = CoreDBSpec::default();
         let cloud_provider = CloudProvider::Azure;
-        
+
         let result = generate_spec(
             "org-id",
             "entity-name",

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn generate_spec(
     azure_storage_account: Option<&str>,
     spec: &CoreDBSpec,
     cloud_provider: &CloudProvider,
+    storage_class_name: &str,
 ) -> Result<Value, ConductorError> {
     let mut spec = spec.clone();
 
@@ -77,9 +78,9 @@ pub async fn generate_spec(
                 }
             }
 
-            // If the cloud provider is Azure, set the storageClass to tembo-csi
-            if *cloud_provider == CloudProvider::Azure {
-                spec.storage_class = Some("tembo-csi".to_string());
+            // Set the storageClass to the value of storage_class_name if not empty
+            if !storage_class_name.is_empty() {
+                spec.storage_class = Some(storage_class_name.to_string());
             }
         }
         CloudProvider::Unknown => {
@@ -764,6 +765,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -796,6 +798,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -826,6 +829,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -849,6 +853,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -875,6 +880,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -905,6 +911,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");
@@ -935,6 +942,7 @@ mod tests {
             Some("eusdevsg"),
             &spec,
             &cloud_provider,
+            "tembo-csi",
         )
         .await
         .expect("Failed to generate spec");
@@ -966,6 +974,7 @@ mod tests {
             Some("eusdevsg"),
             &spec,
             &cloud_provider,
+            "tembo-csi",
         )
         .await
         .expect("Failed to generate spec");
@@ -993,12 +1002,12 @@ mod tests {
             Some("eusdevsg"),
             &spec,
             &cloud_provider,
+            "tembo-csi",
         )
         .await
         .expect("Failed to generate spec");
 
         // Verify Azure storage class is set correctly
-        println!("result: {:?}", result);
         assert_eq!(
             result["spec"]["storageClass"].as_str().unwrap(),
             "tembo-csi",
@@ -1017,6 +1026,7 @@ mod tests {
             None,
             &spec,
             &cloud_provider,
+            "",
         )
         .await
         .expect("Failed to generate spec");

--- a/conductor/src/main.rs
+++ b/conductor/src/main.rs
@@ -112,6 +112,10 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
         .unwrap_or_else(|_| "true".to_owned())
         .parse()
         .expect("error parsing IS_LOADBALANCER_PUBLIC");
+    let storage_class_name: String = env::var("STORAGE_CLASS_NAME")
+        .unwrap_or_else(|_| "".to_owned())
+        .parse()
+        .expect("error parsing STORAGE_CLASS_NAME");
 
     // Error and exit if CF_TEMPLATE_BUCKET is not set when IS_CLOUD_FORMATION is enabled
     if is_cloud_formation && cf_template_bucket.is_empty() {
@@ -428,6 +432,7 @@ async fn run(metrics: CustomMetrics) -> Result<(), ConductorError> {
                     azure_storage_account,
                     &coredb_spec,
                     &cloud_provider,
+                    &storage_class_name,
                 )
                 .await?;
 


### PR DESCRIPTION
We need to set the correct storage class for pods in Azure AKS.

fixes: [TEM-3054](https://linear.app/tembo/issue/TEM-3054/migrate-aks-storage-class-to-use-premium-zrs)