### PR TITLE
Build tembo-pod-init with Rust 1.84

### DIFF
--- a/tembo-pod-init/Dockerfile
+++ b/tembo-pod-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/tembo/rust:1.76-bookworm as builder
+FROM quay.io/tembo/rust:1.84-bookworm as builder
 
 COPY tembo-operator ./tembo-operator
 WORKDIR /tembo-pod-init
@@ -6,7 +6,7 @@ COPY Cargo.toml .
 COPY src/ ./src/
 RUN cargo build --release
 
-FROM quay.io/tembo/debian:12.5-slim
+FROM quay.io/tembo/debian:12.9-slim
 RUN set -eux; \
     apt-get update; \
     apt-get upgrade -y; \


### PR DESCRIPTION
As native-tls now requires Rust 1.80 or newer, 1.76 no longer works. So upgrade to the latest Rust version and also update the version of Debian on which it's installed.