### PR TITLE
Remove pg_tier and parquet_s3_fdw from stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Postgres is the best OSS database in the world, with millions of active deployme
 * [pgmq](https://github.com/tembo-io/pgmq) - a message queue built with Rust, available as a Postgres extension and Rust crate
 * [pg_vectorize](https://github.com/tembo-io/pg_vectorize) - automate vector search workflow, and SQL access to 100+ OSS sentence transformer models
 * [pg_later](https://github.com/tembo-io/pg_later) - a Postgres extension for completely asynchronous query execution
-* [pg_tier](https://github.com/tembo-io/pg_tier) - a Postgres Extension to enable data tiering to AWS S3
 * [pg_timeseries](https://github.com/tembo-io/pg_timeseries) - a Postgres Extension to provide simple and focused time-series tables
 * [pg_auto_dw](https://github.com/tembo-io/pg_auto_dw) - An auto data warehouse extension for Postgres
 

--- a/tembo-operator/yaml/sample-message-queue.yaml
+++ b/tembo-operator/yaml/sample-message-queue.yaml
@@ -39,10 +39,6 @@ spec:
       version: 1.1.0
     - name: pg_partman
       version: 4.7.3
-    - name: parquet_s3_fdw
-      version: 1.1.0
-    - name: pg_tier
-      version: 0.0.3
   extensions:
     - name: pgmq
       locations:
@@ -54,16 +50,6 @@ spec:
         - database: postgres
           enabled: true
           version: 4.7.3
-    - name: parquet_s3_fdw
-      locations:
-        - database: postgres
-          enabled: true
-          version: 1.1.0
-    - name: pg_tier
-      locations:
-        - database: postgres
-          enabled: true
-          version: 0.0.3
   metrics:
     enabled: true
     image: quay.io/prometheuscommunity/postgres-exporter:v0.12.0

--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.25.7"
+version = "0.25.8"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/analytics.yaml
+++ b/tembo-stacks/src/stacks/specs/analytics.yaml
@@ -3,9 +3,9 @@ description: A Postgres instance optimized for analytics workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "analytics-cnpg:14-274af6e"
-  15: "analytics-cnpg:15-274af6e"
-  16: "analytics-cnpg:16-274af6e"
+  14: "standard-cnpg:14-274af6e"
+  15: "standard-cnpg:15-274af6e"
+  16: "standard-cnpg:16-274af6e"
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:
@@ -50,8 +50,6 @@ trunk_installs:
     version: 0.4.3
   - name: multicorn
     version: 2.5.0
-  - name: pg_tier
-    version: 0.0.5
   - name: pg_duckdb
     version: 0.2.0
 extensions:

--- a/tembo-stacks/src/stacks/specs/message_queue.yaml
+++ b/tembo-stacks/src/stacks/specs/message_queue.yaml
@@ -55,10 +55,6 @@ trunk_installs:
     version: 1.5.0
   - name: pg_partman
     version: 5.2.4
-  - name: parquet_s3_fdw
-    version: 1.1.0
-  - name: pg_tier
-    version: 0.0.4
 extensions:
   - name: pgmq
     locations:
@@ -76,16 +72,6 @@ extensions:
       - database: postgres
         enabled: true
         version: 5.2.4
-  - name: parquet_s3_fdw
-    locations:
-      - database: postgres
-        enabled: true
-        version: 1.1.0
-  - name: pg_tier
-    locations:
-      - database: postgres
-        enabled: true
-        version: 0.0.4
 postgres_metrics:
   pgmq:
       query: select queue_name, queue_length, oldest_msg_age_sec, newest_msg_age_sec, total_messages, current_database() as datname from pgmq.metrics_all()

--- a/tembo-stacks/src/stacks/specs/timeseries.yaml
+++ b/tembo-stacks/src/stacks/specs/timeseries.yaml
@@ -40,10 +40,6 @@ trunk_installs:
     version: 5.2.4
   - name: pg_stat_statements
     version: 1.11.0
-  - name: parquet_s3_fdw
-    version: 1.1.0
-  - name: pg_tier
-    version: 0.0.4
 extensions:
   - name: columnar
     locations:
@@ -77,13 +73,3 @@ extensions:
       - database: postgres
         enabled: true
         version: 1.11.0
-  - name: parquet_s3_fdw
-    locations:
-      - database: postgres
-        enabled: true
-        version: 1.1.0
-  - name: pg_tier
-    locations:
-      - database: postgres
-        enabled: true
-        version: 0.0.4


### PR DESCRIPTION
`pg_tier` does not work (tem-2870), so remove it. Also remove `parquet_s3_fdw`, since it was only included to support `pg_tier`, and its functionality is covered by `pg_duckdb`, `pg_analytics`, and `duckdb_fdw`.