### PR TITLE
Update stacks to latest images

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.25.8"
+version = "0.25.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.25.8"
+version = "0.25.9"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"

--- a/tembo-stacks/src/stacks/specs/analytics.yaml
+++ b/tembo-stacks/src/stacks/specs/analytics.yaml
@@ -3,9 +3,9 @@ description: A Postgres instance optimized for analytics workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/gis.yaml
+++ b/tembo-stacks/src/stacks/specs/gis.yaml
@@ -3,10 +3,10 @@ description: Postgres for geospatial workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "geo-cnpg:14-274af6e"
-  15: "geo-cnpg:15-274af6e"
-  16: "geo-cnpg:16-274af6e"
-  17: "geo-cnpg:17-274af6e"
+  14: "geo-cnpg:14-ee80907"
+  15: "geo-cnpg:15-ee80907"
+  16: "geo-cnpg:16-ee80907"
+  17: "geo-cnpg:17-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: standard
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/machine_learning.yaml
+++ b/tembo-stacks/src/stacks/specs/machine_learning.yaml
@@ -3,9 +3,9 @@ description: A Postgres instance equipped with machine learning extensions and o
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  15: "ml-cnpg:15-274af6e"
-  16: "ml-cnpg:16-274af6e"
-  17: "ml-cnpg:17-274af6e"
+  15: "ml-cnpg:15-ee80907"
+  16: "ml-cnpg:16-ee80907"
+  17: "ml-cnpg:17-ee80907"
 stack_version: 0.4.0
 compute_constraints:
   min:

--- a/tembo-stacks/src/stacks/specs/message_queue.yaml
+++ b/tembo-stacks/src/stacks/specs/message_queue.yaml
@@ -3,10 +3,10 @@ description: A Tembo Postgres Stack optimized for Message Queue workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.3.0
 appServices:
   - name: mq-api

--- a/tembo-stacks/src/stacks/specs/mongo_alternative.yaml
+++ b/tembo-stacks/src/stacks/specs/mongo_alternative.yaml
@@ -3,10 +3,10 @@ description: Document-facing workloads on Postgres.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.1.0
 appServices:
   - name: fdb-api

--- a/tembo-stacks/src/stacks/specs/oltp.yaml
+++ b/tembo-stacks/src/stacks/specs/oltp.yaml
@@ -3,10 +3,10 @@ description: A Postgres instance optimized for OLTP workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: standard
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/paradedb.yaml
+++ b/tembo-stacks/src/stacks/specs/paradedb.yaml
@@ -3,10 +3,10 @@ description: Postgres for Search and Analytics
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: paradedb
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/standard.yaml
+++ b/tembo-stacks/src/stacks/specs/standard.yaml
@@ -3,10 +3,10 @@ description: A balanced Postgres instance optimized for OLTP workloads.
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: standard
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/timeseries.yaml
+++ b/tembo-stacks/src/stacks/specs/timeseries.yaml
@@ -3,9 +3,9 @@ description: A Postgres instance equipped with configuration and extensions for 
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
 stack_version: 0.1.0
 postgres_config_engine: olap
 postgres_config:

--- a/tembo-stacks/src/stacks/specs/vectordb.yaml
+++ b/tembo-stacks/src/stacks/specs/vectordb.yaml
@@ -3,10 +3,10 @@ description: A Tembo Postgres Stack configured to support vector data types, sto
 repository: "quay.io/tembo"
 organization: tembo
 images:
-  14: "standard-cnpg:14-274af6e"
-  15: "standard-cnpg:15-274af6e"
-  16: "standard-cnpg:16-274af6e"
-  17: "standard-cnpg:17-274af6e"
+  14: "standard-cnpg:14-ee80907"
+  15: "standard-cnpg:15-ee80907"
+  16: "standard-cnpg:16-ee80907"
+  17: "standard-cnpg:17-ee80907"
 stack_version: 0.1.0
 appServices:
   - image: 387894460527.dkr.ecr.us-east-1.amazonaws.com/tembo-io/vector-serve:df68795


### PR DESCRIPTION
These images remove `pg_tier` and `parquet_s3_fdw` (TEM-2870).