### PR TITLE
Copy /tmp/pg_sharedir only if exists

### DIFF
--- a/tembo-pod-init/src/container.rs
+++ b/tembo-pod-init/src/container.rs
@@ -63,7 +63,7 @@ pub async fn create_init_container(
         command: Some(vec![
             "/bin/bash".to_string(),
             "-c".to_string(),
-            "if [ -d /var/lib/postgresql/data/tembo ]; then if [ -z \"$(ls -A /var/lib/postgresql/data/tembo)\" ]; then cp -Rp /tmp/pg_sharedir/. /var/lib/postgresql/data/tembo; fi; else mkdir -p /var/lib/postgresql/data/tembo && cp -Rp /tmp/pg_sharedir/. /var/lib/postgresql/data/tembo; fi".to_string(),
+            "mkdir -p /var/lib/postgresql/data/tembo; if [ -d /tmp/pg_sharedir ] && [ -z \"$(ls -A /var/lib/postgresql/data/tembo)\" ]; then cp -Rp /tmp/pg_sharedir/. /var/lib/postgresql/data/tembo; fi".to_string(),
             "if [-d /var/lib/postgresql/data/lost+found ]; then rmdir /var/lib/postgresql/data/lost+found; fi".to_string(),
         ]),
         security_context: Some(security_context),
@@ -79,7 +79,7 @@ pub fn add_volume_mounts(container: &mut Container, volume_mount: VolumeMount) {
     if container
         .volume_mounts
         .as_ref()
-        .map_or(false, |volume_mounts| {
+        .is_some_and(|volume_mounts| {
             volume_mounts
                 .iter()
                 .any(|v| v.name == volume_mount.name && v.mount_path == volume_mount.mount_path)

--- a/tembo-pod-init/src/main.rs
+++ b/tembo-pod-init/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> std::io::Result<()> {
 
     // Set trace_id for logging
     let trace_id = telemetry_config.get_trace_id();
-    Span::current().record("trace_id", &field::display(&trace_id));
+    Span::current().record("trace_id", field::display(&trace_id));
 
     let stop_handle = web::Data::new(StopHandle::default());
 

--- a/tembo-pod-init/src/mutate.rs
+++ b/tembo-pod-init/src/mutate.rs
@@ -26,7 +26,7 @@ async fn mutate(
 ) -> impl Responder {
     // Set trace_id for logging
     let trace_id = tc.get_trace_id();
-    Span::current().record("trace_id", &field::display(&trace_id));
+    Span::current().record("trace_id", field::display(&trace_id));
 
     // Extract the AdmissionRequest from the AdmissionReview
     let admission_request: AdmissionRequest<Pod> = body.clone().request.unwrap();
@@ -105,9 +105,7 @@ async fn mutate(
         .metadata
         .annotations
         .as_ref()
-        .map_or(false, |annotations| {
-            annotations.contains_key(&config.pod_annotation)
-        })
+        .is_some_and(|annotations| annotations.contains_key(&config.pod_annotation))
     {
         return match ar.request {
             Some(request) => HttpResponse::Ok().json(AdmissionReview {
@@ -149,7 +147,7 @@ async fn mutate(
         if spec
             .init_containers
             .as_ref()
-            .map_or(false, |init_containers| {
+            .is_some_and(|init_containers| {
                 init_containers
                     .iter()
                     .any(|c| c.name == config.init_container_name)


### PR DESCRIPTION
Since some images may not have `/tmp/pg_sharedir`, change the logic to copy it only if it exists. Simplify the conditional to always run `mkdir -p`.

Also: fix clippy issues.