### PR TITLE
Refactor shell commands on container init

### DIFF
--- a/tembo-pod-init/src/container.rs
+++ b/tembo-pod-init/src/container.rs
@@ -56,6 +56,7 @@ pub async fn create_init_container(
     };
 
     // Create the initContainer
+    let script = include_str!("init-dirs.sh");
     Container {
         name: config.init_container_name.to_string(),
         image: Some(image),
@@ -63,8 +64,7 @@ pub async fn create_init_container(
         command: Some(vec![
             "/bin/bash".to_string(),
             "-c".to_string(),
-            "mkdir -p /var/lib/postgresql/data/tembo; if [ -d /tmp/pg_sharedir ] && [ -z \"$(ls -A /var/lib/postgresql/data/tembo)\" ]; then cp -Rp /tmp/pg_sharedir/. /var/lib/postgresql/data/tembo; fi".to_string(),
-            "if [-d /var/lib/postgresql/data/lost+found ]; then rmdir /var/lib/postgresql/data/lost+found; fi".to_string(),
+            script.to_string(),
         ]),
         security_context: Some(security_context),
         volume_mounts: Some(volume_mounts),

--- a/tembo-pod-init/src/init-dirs.sh
+++ b/tembo-pod-init/src/init-dirs.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Only copy sharedir if it is empty.
+sharedir="$(pg_config --sharedir)"
+mkdir -p "${sharedir}"
+if [ -d /tmp/pg_sharedir ] && [ -z "${sharedir}" ]; then
+    cp -Rp /tmp/pg_sharedir/. "${sharedir}";
+fi
+
+# Always copy the contents of pkglibdir
+pkglibdir="$(pg_config --pkglibdir)"
+mkdir -p "${pkglibdir}"
+if [ -d /tmp/pg_pkglibdir ]; then
+    cp -Rp /tmp/pg_pkglibdir/. "${pkglibdir}";
+fi
+
+if [ -d /var/lib/postgresql/data/lost+found ]; then
+    rmdir /var/lib/postgresql/data/lost+found;
+fi


### PR DESCRIPTION
Move the shell commands to a script, `init-dirs.sh`, and embed it in the binary. This makes it easier to maintain the shell script without Rust escapes and no line breaks.

Change the script behavior to not only copy the contents of `/tmp/pg_sharedir` if sharedir is empty, but also always copy the contents of `/tmp/pg_pkglibdir`, as a minor version upgrade might include improvements or bug fixes.