### PR TITLE
revert back to latest for operator and pod-init deployments

### DIFF
--- a/conductor/testdata/operator-values.yaml
+++ b/conductor/testdata/operator-values.yaml
@@ -1,6 +1,6 @@
 controller:
   image:
-    tag: "fd5caf6"
+    tag: latest
   extraEnv:
     - name: ENABLE_BACKUP
       value: "false"
@@ -9,7 +9,7 @@ controller:
 
 pod-init:
   image:
-    tag: "fd5caf6"
+    tag: latest
   logLevel: info
   extraEnv:
     - name: RUST_LOG

--- a/tembo-operator/testdata/operator-values.yaml
+++ b/tembo-operator/testdata/operator-values.yaml
@@ -3,7 +3,7 @@ controller:
 
 pod-init:
   image:
-    tag: "fd5caf6"
+    tag: latest
   logLevel: info
   resources:
     requests:


### PR DESCRIPTION
Revert back to using `latest` tag for operator and pod-init deployments in test