### PR TITLE
rework delete function to not requeue

### DIFF
--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7347a3d65cd64db51e5b4aebf0c68c484042948c6d53f856f58269bc9816360"
+checksum = "34a73d9e94d35665909050f02e035d8bdc82e419241b1b027ebf1ea51dc8a470"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3544,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+checksum = "64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/conductor/Cargo.lock
+++ b/conductor/Cargo.lock
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "0.24.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a73d9e94d35665909050f02e035d8bdc82e419241b1b027ebf1ea51dc8a470"
+checksum = "c7347a3d65cd64db51e5b4aebf0c68c484042948c6d53f856f58269bc9816360"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3544,9 +3544,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -33,7 +33,7 @@ prometheus = "0.13"
 sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres"] }
 anyhow = "1.0.82"
 serde_yaml = "0.9.34"
-reqwest = { version = "0.12.3", features = ["json"] }
+reqwest = { version = "=0.12.12", features = ["json"] }
 google-cloud-storage = "=0.22.1"
 azure_identity = "0.21"
 azure_mgmt_msi = "0.21"

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -34,7 +34,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres"] }
 anyhow = "1.0.82"
 serde_yaml = "0.9.34"
 reqwest = { version = "=0.12.12", features = ["json"] }
-google-cloud-storage = "=0.22.1"
+google-cloud-storage = "0.24"
 azure_identity = "0.21"
 azure_mgmt_msi = "0.21"
 azure_mgmt_authorization = "0.21"

--- a/conductor/Cargo.toml
+++ b/conductor/Cargo.toml
@@ -34,7 +34,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio-native-tls", "postgres"] }
 anyhow = "1.0.82"
 serde_yaml = "0.9.34"
 reqwest = { version = "0.12.3", features = ["json"] }
-google-cloud-storage = "0.24"
+google-cloud-storage = "=0.22.1"
 azure_identity = "0.21"
 azure_mgmt_msi = "0.21"
 azure_mgmt_authorization = "0.21"

--- a/conductor/src/lib.rs
+++ b/conductor/src/lib.rs
@@ -241,7 +241,10 @@ async fn delete(client: Client, namespace: &str, name: &str) -> Result<(), Condu
         }
     }
 
-    info!("Timeout waiting for CoreDB {} to be deleted, but continuing", name);
+    info!(
+        "Timeout waiting for CoreDB {} to be deleted, but continuing",
+        name
+    );
     Ok(())
 }
 
@@ -291,7 +294,10 @@ async fn delete_namespace(client: Client, name: &str) -> Result<(), ConductorErr
     // Initiate namespace deletion
     match ns_api.delete(name, &params).await {
         Ok(_) => {
-            info!("Delete request for namespace {} initiated successfully", name);
+            info!(
+                "Delete request for namespace {} initiated successfully",
+                name
+            );
         }
         Err(kube::Error::Api(err)) if err.code == 404 => {
             // Namespace doesn't exist, log and continue
@@ -328,7 +334,10 @@ async fn delete_namespace(client: Client, name: &str) -> Result<(), ConductorErr
         }
     }
 
-    info!("Timeout waiting for namespace {} to be deleted, but continuing", name);
+    info!(
+        "Timeout waiting for namespace {} to be deleted, but continuing",
+        name
+    );
     Ok(())
 }
 


### PR DESCRIPTION
Rework the `delete` and `delete_namespace` functions to not return `KubeError` if the `CoreDB` or `Namespace` are missing when deleted. 

This was blocking the `Event::Delete` code from progressing