### PR TITLE
Eliminate need for `/tmp/pg_sharedir`

### DIFF
--- a/tembo-pod-init/src/container.rs
+++ b/tembo-pod-init/src/container.rs
@@ -25,9 +25,11 @@ pub async fn create_init_container(
 
     // Add in mounted volumes
     let volume_mounts = vec![
+        // Mount pgdata to an init location so we can copy files the image
+        // has in /var/lib/postgresql/data.
         VolumeMount {
             name: "pgdata".to_string(),
-            mount_path: "/var/lib/postgresql/data".to_string(),
+            mount_path: "/var/lib/postgresql/init".to_string(),
             ..Default::default()
         },
         VolumeMount {

--- a/tembo-pod-init/src/init-dirs.sh
+++ b/tembo-pod-init/src/init-dirs.sh
@@ -1,19 +1,4 @@
 #!/bin/sh
 
-# Only copy sharedir if it is empty.
-sharedir="$(pg_config --sharedir)"
-mkdir -p "${sharedir}"
-if [ -d /tmp/pg_sharedir ] && [ -z "$(ls -A "${sharedir}")" ]; then
-    cp -Rp /tmp/pg_sharedir/. "${sharedir}";
-fi
-
-# Always copy the contents of pkglibdir
-pkglibdir="$(pg_config --pkglibdir)"
-mkdir -p "${pkglibdir}"
-if [ -d /tmp/pg_pkglibdir ]; then
-    cp -Rp /tmp/pg_pkglibdir/. "${pkglibdir}";
-fi
-
-if [ -d /var/lib/postgresql/data/lost+found ]; then
-    rmdir /var/lib/postgresql/data/lost+found;
-fi
+cp -p --recursive --update /var/lib/postgresql/data/* /var/lib/postgresql/init/
+rm --recursive --force /var/lib/postgresql/init/lost+found


### PR DESCRIPTION
Mount the `pgdata` volume in the `tembo-init` container to `/var/lib/postgresql/init` instead of `/var/lib/postgresql/data`. This leaves the contents of `data` from the image in place, and we can simply copy them to `init`, eliminating the need for the images to have copied data to `/tmp/pg_sharedir`.

Update `init-dirs.sh` to make this copy, but switch to `cp --recursive --update`, which will update files but not delete any other files. This will allow change such as minor Postgres version updates to shared libraries to be copied over, ensuring they're consistent with the version of Postgres from the image.

Remove the `/tmp/pg_pkglibdir` copy, as well, as it is included in `data`, and simplify the deletion of
`/var/lib/postgresql/data/lost+found` (which should not be in any of our images anyway).