### PR TITLE
Fix `check_for_so_files()`

### DIFF
--- a/tembo-operator/src/extensions/install.rs
+++ b/tembo-operator/src/extensions/install.rs
@@ -335,8 +335,8 @@ async fn execute_extension_install_command(
         ext.name.clone(),
         "--version".to_owned(),
         version,
-        "--pkglibdir".to_owned(),
-        cdb.spec.module_dir(),
+        // "--pkglibdir".to_owned(),
+        // cdb.spec.module_dir(),
     ];
 
     // If the pod is not up yet, do not try and install the extension
@@ -431,9 +431,11 @@ pub async fn check_for_so_files(
         return Err(Action::requeue(Duration::from_secs(10)));
     }
 
+    let so = format!("{}/{}.so", cdb.spec.module_dir(), extension_name);
     let cmd = vec![
-        "ls".to_owned(),
-        format!("{}/{}.so", cdb.spec.module_dir(), extension_name),
+        "/bin/bash".to_string(),
+        "-c".to_string(),
+        format!("if [ -f '{so}' ]; then echo '{so}'; fi"),
     ];
 
     let result = cdb.exec(pod_name.to_string(), client.clone(), &cmd).await;


### PR DESCRIPTION
Broken in 2befbb0, where I failed to realize that the command would error out if the file did not exist. So teach the `ls` command to ignore errors by sending STDERR to `/dev/null` and to execute `true` if `ls` returns an error.

Also from 2befbb0, comment out the `--pkglibdir` option in the call to `trunk`. It doesn't work for images that don't have a version of Trunk with that option. We can turn it back on once all images have upgraded.