### PR TITLE
    Install extension dependencies for new image

### DIFF
--- a/tembo-operator/src/extensions/dependencies.yaml
+++ b/tembo-operator/src/extensions/dependencies.yaml
@@ -1,0 +1,2 @@
+redis_fdw: [libhiredis]
+pgsql_http: [libbrotli, libldap, libnghttp2, libpsl, librtmp, libssh, libcurl]


### PR DESCRIPTION
Modify `install_extensions_to_pod` to detect when the Pod runs the new Postgres image, and in that case use `tembox` to install dependencies for each extension before installing the extension itself. A new file, `dependencies.yaml`, lists the dependencies for extensions that have them. For now at least this file will need to be maintained in this project.

The install each dependency only once, so if multiple extensions depend on the same package, there is no repetition. This only works because the execution of `install_extensions_to_pod` is synchronous. However, it always installs *all* the dependencies into the pod, even if they were previously installed. This ensures that any dependency updates will be propagated anytime a pod restarts.

The new `execute_dependency_install_command` function follows the pattern of `execute_extension_install_command`, though its three-value logic differs slightly: An error is an error, whereas a false result means try again. In the event of an error, the code does not attempt to install the extension, but moves on to the next extension in the list.

Meanwhile, update `execute_extension_install_command` to pass the `--strip-libdir` and `--pkglibdir` options to `trunk` when the pod uses the new Postgres image, so that shared modules end up in the proper directory and the `$libdir/` prefix is removed from the control file so that Postgres can find them.

While at it, move the repetitive formatting of execution standard and error output to a macro.