### PR TITLE
Add pull_policy to pod init Config

### DIFF
--- a/tembo-pod-init/Cargo.toml
+++ b/tembo-pod-init/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tembo-pod-init"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 
@@ -36,6 +36,7 @@ prometheus = "0.13"
 rustc_version_runtime = "0.3"
 tracing-actix-web = "0.7"
 uuid = { version = "1", features = ["v4"] }
+regex = "1.11.1"
 
 [dependencies.kube]
 features = ["admission", "runtime", "client", "derive", "ws"]

--- a/tembo-pod-init/src/config.rs
+++ b/tembo-pod-init/src/config.rs
@@ -13,6 +13,33 @@ pub struct Config {
     pub opentelemetry_endpoint_url: Option<String>,
 }
 
+impl Config {
+    // Returns true if the configuration uses the Tembo Postgres image.
+    pub fn uses_postgres_image(&self) -> bool {
+        self.container_image.contains("postgres:")
+    }
+
+    // Returns "Always" when the configuration uses the Tembo Postgres image
+    // with a specific Postgres major version and OS name, e.g.,
+    // "quay.io/tembo/postgres:17-noble". Otherwise it returns
+    // "IfNotPresent". The idea is to always pull images for a major Postgres
+    // version and OS version to keep Pods up-to-date, but we don't want to
+    // pull an image unnecessarily if it doesn't contain the Postgres and OS
+    // versions. Because we don't want to change major or OS versions, configs
+    // should always use the `postgres:$pg_major-$os_version` tag.
+    pub fn image_pull_policy(&self) -> Option<String> {
+        let re = regex::Regex::new(r"(?:^|/)postgres:\d+-[a-z]+$").unwrap();
+        Some(
+            if re.is_match(&self.container_image) {
+                "Always"
+            } else {
+                "IfNotPresent"
+            }
+            .to_string(),
+        )
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -59,4 +86,100 @@ fn from_env_or_default(var: &str, default: &str) -> String {
         panic!("{} must be set", var);
     }
     value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_image() {
+        for (name, image, uses, always) in [
+            ("empty", "", false, false),
+            (
+                "old_default",
+                "quay.io/tembo/tembo-pg-cnpg:15.3.0-5-cede445",
+                false,
+                false,
+            ),
+            (
+                "standard_sixteen",
+                "quay.io/tembo/standard-cnpg:16-ee80907",
+                false,
+                false,
+            ),
+            (
+                "gis_fourteen",
+                "quay.io/tembo/geo-cnpg:14-ee80907",
+                false,
+                false,
+            ),
+            (
+                "aws_sixteen",
+                "387894460527.dkr.ecr.us-east-1.amazonaws.com/tembo-io/standard-cnpg:16.1-d15f2dc",
+                false,
+                false,
+            ),
+            (
+                "postgres_seventeen_noble",
+                "quay.io/tembo/postgres:17-noble",
+                true,
+                true,
+            ),
+            (
+                "postgres_seventeen_four_noble",
+                "quay.io/tembo/postgres:17.4-noble",
+                true,
+                false,
+            ),
+            (
+                "postgres_fourteen_jammy",
+                "quay.io/tembo/postgres:14-jammy",
+                true,
+                true,
+            ),
+            (
+                "postgres_fourteen_two_jammy",
+                "quay.io/tembo/postgres:14.2-jammy",
+                true,
+                false,
+            ),
+            ("postgres_sixteen", "quay.io/tembo/postgres:16", true, false),
+            (
+                "postgres_fifteen_timestamp",
+                "quay.io/tembo/postgres:15.12-noble-202503122254",
+                true,
+                false,
+            ),
+            (
+                "old_default_no_registry",
+                "tembo-pg-cnpg:15.3.0-5-cede445",
+                false,
+                false,
+            ),
+            (
+                "postgres_no_registry",
+                "postgres:15.12-noble-202503122254",
+                true,
+                false,
+            ),
+        ] {
+            let config = Config {
+                pod_annotation: "".to_string(),
+                namespace_label: "".to_string(),
+                server_host: "".to_string(),
+                server_port: 5432,
+                container_image: image.to_string(),
+                init_container_name: "".to_string(),
+                tls_cert: "".to_string(),
+                tls_key: "".to_string(),
+                opentelemetry_endpoint_url: None,
+            };
+            assert_eq!(uses, config.uses_postgres_image(), "{name}");
+            assert_eq!(
+                Some(if always { "Always" } else { "IfNotPresent" }.to_string()),
+                config.image_pull_policy(),
+            );
+        }
+    }
 }

--- a/tembo-pod-init/src/container.rs
+++ b/tembo-pod-init/src/container.rs
@@ -62,7 +62,7 @@ pub async fn create_init_container(
     Container {
         name: config.init_container_name.to_string(),
         image: Some(image),
-        image_pull_policy: Some("IfNotPresent".to_string()),
+        image_pull_policy: config.image_pull_policy(),
         command: Some(vec![
             "/bin/bash".to_string(),
             "-c".to_string(),


### PR DESCRIPTION
Add the `uses_postgres_image()` method to `Config` in the `tembo-pod-init` package. Like the method with the same name in `CoreDBSpec` in `tembo-operator`, the method returns true when the image is a base image and false when it's not.

Also add `image_pull_policy()`, which returns returns "Always" when the image name is `postgres` and its tag includes a Postgres major version and OS name. This ensures that on every pod init, it will pull the latest image for that OS and Postgres version. For all other cases it only pulls "IfNotExists".

Increment tembo-pod-stacks to v0.2.1. Closes TEM-3531.