### PR TITLE
fix deps on tembo-operator

### DIFF
--- a/tembo-pod-init/Cargo.toml
+++ b/tembo-pod-init/Cargo.toml
@@ -19,7 +19,7 @@ k8s-openapi = { version = "0.24.0", features = [
   "schemars",
 ], default-features = false }
 serde_json = "1.0"
-json-patch = "3" # Version 3 is required for kube-rs compatibility
+json-patch = "4" # Version 3 is required for kube-rs compatibility
 parking_lot = "0.12"
 futures = "0.3"
 openssl = { version = "0.10", features = ["vendored"] }
@@ -40,4 +40,4 @@ regex = "1.11.1"
 
 [dependencies.kube]
 features = ["admission", "runtime", "client", "derive", "ws"]
-version = "0.98.0"
+version = "0.99.0"


### PR DESCRIPTION
Fixes a crate dependency with `tembo-operator`

```
#13 156.6 error[E0277]: the trait bound `controller::cloudnativepg::clusters::Cluster: k8s_openapi::Metadata` is not satisfied
#13 156.6   --> src/container.rs:17:37
#13 156.6    |
#13 156.6 17 |     let cluster_api: Api<Cluster> = Api::namespaced(client.clone(), namespace);
#13 156.6    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `k8s_openapi::Metadata` is not implemented for `controller::cloudnativepg::clusters::Cluster`
#13 156.6    |
#13 156.6    = help: the following other types implement trait `k8s_openapi::Metadata`:
#13 156.6              APIService
#13 156.6              Binding
#13 156.6              CSIDriver
#13 156.6              CSINode
#13 156.6              CSIStorageCapacity
#13 156.6              CertificateSigningRequest
#13 156.6              ClusterRole
#13 156.6              ClusterRoleBinding
#13 156.6            and 77 others
#13 156.6    = note: required for `controller::cloudnativepg::clusters::Cluster` to implement `kube::Resource`
#13 156.6 
#13 156.9 For more information about this error, try `rustc --explain E0277`.
#13 156.9 error: could not compile `tembo-pod-init` (lib) due to 1 previous error
```