### PR TITLE
bump controller version in stacks

### DIFF
--- a/tembo-stacks/Cargo.lock
+++ b/tembo-stacks/Cargo.lock
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "controller"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c0e69ecdd748cbf97edeaa5f7b640d6e0234f61336a358feba4171200b705f"
+checksum = "d59155eb7b240ef28214acd7c7c6eea2aa6ac72f0169dd189ef823cd464f60f3"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "tembo-stacks"
-version = "0.26.8"
+version = "0.26.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/tembo-stacks/Cargo.toml
+++ b/tembo-stacks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tembo-stacks"
 description = "Tembo Stacks for Postgres"
-version = "0.26.8"
+version = "0.26.9"
 authors = ["tembo.io"]
 edition = "2021"
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ serde_json = "1.0.114"
 serde_yaml = "0.9.21"
 strum = "0.26.2"
 strum_macros = "0.26.2"
-tembo-controller = { package = "controller", version = "0.57.0" }
+tembo-controller = { package = "controller", version = "0.58.0" }
 tracing = "0.1"
 utoipa = { version = "3", features = ["actix_extras", "chrono"] }
 


### PR DESCRIPTION
Update tembo-operator version to `0.58.0`

- Linear: [TEM-3592](https://linear.app/tembo/issue/TEM-3592/update-tembo-stacks-to-latest-controller-version)