### PR TITLE
Fixes to the backup download API

### DIFF
--- a/dataplane-webserver/Cargo.lock
+++ b/dataplane-webserver/Cargo.lock
@@ -104,7 +104,6 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
- "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -419,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -454,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -471,7 +470,6 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -480,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.82.0"
+version = "1.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6eab2900764411ab01c8e91a76fd11a63b4e12bc3da97d9e14a0ce1343d86d3"
+checksum = "51384750334005f40e1a334b0d54eca822a77eacdcf3c50fdf38f583c5eee7a2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -585,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -601,7 +599,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.1.0",
- "once_cell",
  "p256",
  "percent-encoding",
  "ring 0.17.8",
@@ -811,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1320,7 +1317,6 @@ name = "dataplane_webserver"
 version = "0.0.1"
 dependencies = [
  "actix-cors",
- "actix-rt",
  "actix-web",
  "aws-config",
  "aws-sdk-s3",
@@ -1339,6 +1335,7 @@ dependencies = [
  "promql-parser",
  "regex",
  "reqwest",
+ "rustls 0.23.23",
  "serde",
  "serde_json",
  "thiserror 2.0.12",

--- a/dataplane-webserver/Cargo.toml
+++ b/dataplane-webserver/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 actix-cors = "0.7"
 actix-web = "4.10"
-actix-rt = "2"
+rustls = "0.23"
 chrono = "0.4.24"
 env_logger = "0.11"
 base64 = "0.22"
@@ -29,9 +29,9 @@ k8s-openapi = { version = "0.24.0", features = ["v1_30"] }
 indexmap = "2"
 regex = "1"
 jsonwebtoken = "8.3.0"
-aws-sdk-s3 = "1.82.0"
-aws-config = "1.6.1"
-aws-smithy-types = "1.3.1"
+aws-sdk-s3 = { version = "1.83", features = ["rt-tokio"] }
+aws-config = "1.6"
+aws-smithy-types = "1.3"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 controller = { version = "0.58.0", package = "controller" }

--- a/dataplane-webserver/Dockerfile
+++ b/dataplane-webserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/tembo/rust:1.85-bookworm AS builder
+FROM quay.io/tembo/rust:1.86-bookworm AS builder
 RUN set -eux; \
   apt-get update; \
   apt-get upgrade -y; \
@@ -9,11 +9,11 @@ WORKDIR /build
 COPY . .
 RUN cargo build --release
 
-FROM quay.io/tembo/debian:12.9-slim
+FROM quay.io/tembo/debian:12.10-slim
 RUN set -eux; \
   apt-get update; \
   apt-get upgrade -y; \
-  apt-get install -y --no-install-recommends openssl; \
+  apt-get install -y --no-install-recommends openssl ca-certificates; \
   apt-get autoremove -y; \
   apt-get clean; \
   rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*

--- a/dataplane-webserver/src/config.rs
+++ b/dataplane-webserver/src/config.rs
@@ -42,7 +42,7 @@ impl Default for Config {
                     300
                 }
             },
-            temback_version: from_env_default("TEMBACK_VERSION", "v0.1.1"),
+            temback_version: from_env_default("TEMBACK_VERSION", "v0.2.1"),
         }
     }
 }

--- a/dataplane-webserver/src/main.rs
+++ b/dataplane-webserver/src/main.rs
@@ -20,6 +20,8 @@ use utoipa_swagger_ui::{SwaggerUi, Url};
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("debug"));
+    rustls::crypto::CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider())
+        .expect("Failed to install rustls CryptoProvider");
 
     let cfg = config::Config::default();
     info!("{:?}", cfg);


### PR DESCRIPTION
There are quite a few fixes in here

* Remove `actix-rt` crate in favor of using `actix_web::rt::spawn` instead
* The `aws-sdk-s3` client requires to explicitly install a process-level CryptoProvider with `rustls`
* Use server-side-encryption with `put_object()` method
* Update `Dockerfile` to install `ca-certificates` and to update to `debian:12.10-slim` and `rust:1.86-bookworm`
* Rework how we install/execute the `temback` binary
* Ensure the backup is present in the backup bucket