### PR TITLE
Add `disable_ingress` config to CoreDB spec

### DIFF
--- a/charts/tembo-operator/templates/crd.yaml
+++ b/charts/tembo-operator/templates/crd.yaml
@@ -2304,6 +2304,13 @@ spec:
                       **Default**: LoadBalancer.
                     type: string
                 type: object
+              disableIngress:
+                default: false
+                description: |-
+                  Disable ingress, so that the instance is inaccessible from outside the cluster.
+
+                  **Default**: false
+                type: boolean
               extensions:
                 default: []
                 description: |-

--- a/tembo-operator/src/apis/coredb_types.rs
+++ b/tembo-operator/src/apis/coredb_types.rs
@@ -590,6 +590,14 @@ pub struct CoreDBSpec {
     #[serde(rename = "ipAllowList")]
     pub ip_allow_list: Option<Vec<String>>,
 
+    /// Disable ingress, so that the instance is inaccessible from outside the
+    /// cluster.
+    ///
+    /// **Default**: false
+    #[serde(rename = "disableIngress")]
+    #[serde(default = "defaults::default_disable_ingress")]
+    pub disable_ingress: bool,
+
     /// The stack configuration for the CoreDB instance.  This is mainly used for the
     /// [https://tembo.io](https://tembo.io) platform to allow for the deployment of
     /// pre-configured Postgres instances.

--- a/tembo-operator/src/app_service/manager.rs
+++ b/tembo-operator/src/app_service/manager.rs
@@ -952,35 +952,56 @@ pub async fn reconcile_app_services(
         .collect();
     let apply_errored = apply_resources(resources.clone(), &client, &ns).await;
 
-    let desired_routes: Vec<IngressRouteRoutes> = resources
-        .iter()
-        .filter_map(|r| r.ingress_routes.clone())
-        .flatten()
-        .collect();
+    // Collect routes and middlewares only if `disable_ingress` is false.
+    let desired_routes: Vec<IngressRouteRoutes> = if cdb.spec.disable_ingress {
+        vec![]
+    } else {
+        resources
+            .iter()
+            .filter_map(|r| r.ingress_routes.clone())
+            .flatten()
+            .collect()
+    };
 
-    let desired_tcp_routes: Vec<IngressRouteTCPRoutes> = resources
-        .iter()
-        .filter_map(|r| r.ingress_tcp_routes.clone())
-        .flatten()
-        .collect();
+    let desired_tcp_routes: Vec<IngressRouteTCPRoutes> = if cdb.spec.disable_ingress {
+        vec![]
+    } else {
+        resources
+            .iter()
+            .filter_map(|r| r.ingress_tcp_routes.clone())
+            .flatten()
+            .collect()
+    };
 
-    let desired_middlewares = appsvcs
-        .iter()
-        .filter_map(|appsvc| appsvc.middlewares.clone())
-        .flatten()
-        .collect::<Vec<Middleware>>();
+    let desired_middlewares = if cdb.spec.disable_ingress {
+        vec![]
+    } else {
+        appsvcs
+            .iter()
+            .filter_map(|appsvc| appsvc.middlewares.clone())
+            .flatten()
+            .collect::<Vec<Middleware>>()
+    };
 
-    let desired_entry_points = resources
-        .iter()
-        .filter_map(|r| r.entry_points.clone())
-        .flatten()
-        .collect::<Vec<String>>();
+    let desired_entry_points = if cdb.spec.disable_ingress {
+        vec![]
+    } else {
+        resources
+            .iter()
+            .filter_map(|r| r.entry_points.clone())
+            .flatten()
+            .collect::<Vec<String>>()
+    };
 
-    let desired_entry_points_tcp = resources
-        .iter()
-        .filter_map(|r| r.entry_points_tcp.clone())
-        .flatten()
-        .collect::<Vec<String>>();
+    let desired_entry_points_tcp = if cdb.spec.disable_ingress {
+        vec![]
+    } else {
+        resources
+            .iter()
+            .filter_map(|r| r.entry_points_tcp.clone())
+            .flatten()
+            .collect::<Vec<String>>()
+    };
 
     // Only reconcile IngressRoute and IngressRouteTCP if DATA_PLANE_BASEDOMAIN is set
     if domain.is_some() {

--- a/tembo-operator/src/defaults.rs
+++ b/tembo-operator/src/defaults.rs
@@ -127,6 +127,10 @@ pub fn default_stop() -> bool {
     false
 }
 
+pub fn default_disable_ingress() -> bool {
+    false
+}
+
 pub fn default_extensions_updating() -> bool {
     false
 }


### PR DESCRIPTION
When it's true, remove all routes and middlewares. Defaults to false.