### PR TITLE
rework backup process to create job and pod

### DIFF
--- a/dataplane-webserver/src/backups/coredb.rs
+++ b/dataplane-webserver/src/backups/coredb.rs
@@ -1,0 +1,132 @@
+use actix_web::{
+    error::{ErrorInternalServerError, ErrorNotFound},
+    Error,
+};
+use controller::apis::coredb_types::CoreDB;
+use kube::{api::Api, Client as KubeClient};
+
+/// Fetches the CoreDB custom resource in the given namespace from the Kubernetes cluster.
+///
+/// # Arguments
+/// * `kube_client` - Reference to the Kubernetes client used to interact with the cluster.
+/// * `namespace` - The namespace in which to look for the CoreDB resource. The CoreDB resource is expected to have the same name as the namespace.
+///
+/// # Returns
+/// * `Ok(CoreDB)` if the resource is found successfully.
+/// * `Err(Error)` if the resource cannot be fetched from the cluster.
+///
+/// # Errors
+/// Returns an Actix `ErrorInternalServerError` if the CoreDB resource cannot be retrieved from the cluster.
+pub async fn fetch_coredb(kube_client: &KubeClient, namespace: &str) -> Result<CoreDB, Error> {
+    let coredb_api = Api::namespaced(kube_client.clone(), namespace);
+    let coredb = coredb_api
+        .get(namespace)
+        .await
+        .map_err(|e| ErrorNotFound(format!("Failed to get CoreDB or CoreDB not found: {}", e)))?;
+    Ok(coredb)
+}
+
+/// Retrieves and parses the S3 backup path from a CoreDB instance's backup configuration.
+///
+/// # Arguments
+/// * `coredb` - Reference to the CoreDB resource
+///
+/// # Returns
+/// * `Ok((String, String))` - Tuple of (bucket_name, object_path)
+/// * `Err(Error)` - If backup configuration is missing or invalid
+pub fn get_backup_path_from_coredb(coredb: &CoreDB) -> Result<(String, String), Error> {
+    let backup = &coredb.spec.backup;
+    if let Some(destination_path) = &backup.destinationPath {
+        tracing::info!(
+            destination_path = %destination_path,
+            "Found backup destination path"
+        );
+
+        // Parse the S3 URI (format: s3://bucket-name/path/to/directory)
+        if let Some(path_without_prefix) = destination_path.strip_prefix("s3://") {
+            // Split by the first slash to separate bucket and path
+            if let Some(first_slash_pos) = path_without_prefix.find('/') {
+                let bucket_name = &path_without_prefix[0..first_slash_pos];
+                let object_path = &path_without_prefix[first_slash_pos + 1..];
+                tracing::info!(
+                    bucket = %bucket_name,
+                    path = %object_path,
+                    "Parsed S3 URI components"
+                );
+                Ok((bucket_name.to_string(), object_path.to_string()))
+            } else {
+                Ok((path_without_prefix.to_string(), "".to_string()))
+            }
+        } else {
+            Err(ErrorInternalServerError(format!(
+                "Destination path is not a valid S3 URI: {}",
+                destination_path
+            )))
+        }
+    } else {
+        Err(ErrorInternalServerError(
+            "CoreDB backup configuration does not contain a destination path".to_string(),
+        ))
+    }
+}
+
+/// Returns the value of the `spec.storage` field from a CoreDB resource as a String.
+///
+/// # Arguments
+/// * `coredb` - Reference to the CoreDB resource
+///
+/// # Returns
+/// * `Ok(String)` containing the storage size (e.g., "10Gi") if present.
+/// * `Err(Error)` if the field is missing.
+pub fn get_storage_size_from_coredb(coredb: &CoreDB) -> Result<String, Error> {
+    Ok(coredb.spec.storage.0.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::error::ErrorInternalServerError;
+
+    /// Helper function to test S3 URI parsing logic directly
+    fn parse_s3_uri(uri: &str) -> Result<(String, String), Error> {
+        if let Some(path_without_prefix) = uri.strip_prefix("s3://") {
+            if let Some(first_slash_pos) = path_without_prefix.find('/') {
+                let bucket_name = &path_without_prefix[0..first_slash_pos];
+                let object_path = &path_without_prefix[first_slash_pos + 1..];
+                Ok((bucket_name.to_string(), object_path.to_string()))
+            } else {
+                Ok((path_without_prefix.to_string(), "".to_string()))
+            }
+        } else {
+            Err(ErrorInternalServerError(format!(
+                "Destination path is not a valid S3 URI: {}",
+                uri
+            )))
+        }
+    }
+
+    #[test]
+    fn test_s3_uri_parsing() {
+        // Test case from the example configuration
+        let result =
+            parse_s3_uri("s3://cdb-plat-use1-dev-instance-backups/v2/sorely-adapted-redpoll")
+                .expect("Should parse valid URI");
+        assert_eq!(result.0, "cdb-plat-use1-dev-instance-backups");
+        assert_eq!(result.1, "v2/sorely-adapted-redpoll");
+
+        // Test bucket only
+        let result = parse_s3_uri("s3://my-bucket").expect("Should parse bucket-only URI");
+        assert_eq!(result.0, "my-bucket");
+        assert_eq!(result.1, "");
+
+        // Test multiple path segments
+        let result = parse_s3_uri("s3://bucket/path/to/backup/dir")
+            .expect("Should parse multi-segment path");
+        assert_eq!(result.0, "bucket");
+        assert_eq!(result.1, "path/to/backup/dir");
+
+        // Test invalid URI (no s3:// prefix)
+        assert!(parse_s3_uri("invalid-uri").is_err());
+        assert!(parse_s3_uri("http://wrong-protocol").is_err());
+    }
+}

--- a/dataplane-webserver/src/backups/job.rs
+++ b/dataplane-webserver/src/backups/job.rs
@@ -1,0 +1,255 @@
+use crate::backups::types::JobStatus;
+use actix_web::{error::ErrorInternalServerError, Error};
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::batch::v1::Job as K8sJob;
+use k8s_openapi::api::core::v1::{
+    Container, EnvFromSource, EphemeralVolumeSource, PersistentVolumeClaimSpec,
+    PersistentVolumeClaimTemplate, PodSpec, PodTemplateSpec, SecretEnvSource, Toleration, Volume,
+    VolumeMount, VolumeResourceRequirements,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use kube::{
+    api::{ObjectMeta, PostParams},
+    Api, Client as KubeClient,
+};
+use std::collections::BTreeMap;
+use tracing;
+
+/// Creates a Kubernetes Job to run a temback backup in the given namespace.
+///
+/// The Job will:
+/// - Use the `{namespace}-connection` secret via envFrom for connection info
+/// - Mount a generic ephemeral volume (PersistentVolumeClaimTemplate) sized to the given storage_size using the 'gp3-enc' StorageClass
+/// - Run the temback command, using env vars for connection info
+/// - Use the provided temback_image
+///
+/// # Arguments
+/// * `kube_client` - Kubernetes client
+/// * `namespace` - Namespace to create the Job in
+/// * `job_id` - Unique job identifier (used for Job name)
+/// * `s3_bucket` - S3 bucket name
+/// * `s3_path` - S3 object path
+/// * `storage_size` - Size for the ephemeral volume (e.g., "10Gi")
+/// * `temback_image` - Image to use for the temback job
+///
+/// # Returns
+/// * `Ok(())` if the Job is created successfully
+/// * `Err(Error)` if Job creation fails
+pub async fn create_backup_job(
+    kube_client: &KubeClient,
+    namespace: &str,
+    job_id: &str,
+    s3_bucket: &str,
+    s3_path: &str,
+    storage_size: &str,
+    temback_image: &str,
+) -> Result<(), Error> {
+    let job_name = format!("temback-backup-{}", job_id);
+    let secret_name = format!("{namespace}-connection");
+    let volume_name = "backup-tmp";
+    let mount_path = "/backup";
+    let host_rw = format!("{namespace}-rw.{namespace}.svc.cluster.local");
+    let args = [
+        "--name",
+        "$(NAMESPACE)",
+        "--host",
+        "$(HOST_RW)",
+        "--user",
+        "$(user)",
+        "--pass",
+        "$(password)",
+        "--bucket",
+        "$(BUCKET)",
+        "--dir",
+        "$(BUCKET_PATH)",
+        "--cd",
+        "$(MOUNT_PATH)",
+        "--compress",
+        "--clean",
+    ];
+
+    let job = Job {
+        metadata: ObjectMeta {
+            name: Some(job_name.clone()),
+            namespace: Some(namespace.to_string()),
+            ..Default::default()
+        },
+        spec: Some(k8s_openapi::api::batch::v1::JobSpec {
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(
+                        [
+                            ("job-name".to_string(), job_name.clone()),
+                            ("app".to_string(), "temback-backup".to_string()),
+                            ("coredb.io/name".to_string(), namespace.to_string()),
+                        ]
+                        .into_iter()
+                        .collect(),
+                    ),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    containers: vec![Container {
+                        name: "temback".to_string(),
+                        image: Some(temback_image.to_string()),
+                        image_pull_policy: Some("IfNotPresent".to_string()),
+                        args: Some(args.iter().map(|s| s.to_string()).collect()),
+                        env_from: Some(vec![EnvFromSource {
+                            secret_ref: Some(SecretEnvSource {
+                                name: secret_name.clone(),
+                                optional: Some(false),
+                            }),
+                            ..Default::default()
+                        }]),
+                        env: Some(vec![
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "JOB_ID".to_string(),
+                                value: Some(job_id.to_string()),
+                                ..Default::default()
+                            },
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "BUCKET".to_string(),
+                                value: Some(s3_bucket.to_string()),
+                                ..Default::default()
+                            },
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "BUCKET_PATH".to_string(),
+                                value: Some(s3_path.to_string()),
+                                ..Default::default()
+                            },
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "MOUNT_PATH".to_string(),
+                                value: Some(mount_path.to_string()),
+                                ..Default::default()
+                            },
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "HOST_RW".to_string(),
+                                value: Some(host_rw.to_string()),
+                                ..Default::default()
+                            },
+                            k8s_openapi::api::core::v1::EnvVar {
+                                name: "NAMESPACE".to_string(),
+                                value: Some(namespace.to_string()),
+                                ..Default::default()
+                            },
+                        ]),
+                        volume_mounts: Some(vec![VolumeMount {
+                            name: volume_name.to_string(),
+                            mount_path: mount_path.to_string(),
+                            ..Default::default()
+                        }]),
+                        ..Default::default()
+                    }],
+                    node_selector: Some(BTreeMap::from([(
+                        "tembo.io/provisioner".to_string(),
+                        "system".to_string(),
+                    )])),
+                    restart_policy: Some("Never".to_string()),
+                    service_account: Some(namespace.to_string()),
+                    service_account_name: Some(namespace.to_string()),
+                    tolerations: Some(vec![Toleration {
+                        key: Some("tembo.io/system".to_string()),
+                        operator: Some("Equal".to_string()),
+                        value: Some("true".to_string()),
+                        ..Default::default()
+                    }]),
+                    volumes: Some(vec![Volume {
+                        name: volume_name.to_string(),
+                        ephemeral: Some(EphemeralVolumeSource {
+                            volume_claim_template: Some(PersistentVolumeClaimTemplate {
+                                metadata: Some(ObjectMeta {
+                                    labels: Some(
+                                        [
+                                            ("app".to_string(), "temback-backup".to_string()),
+                                            ("job-name".to_string(), job_name.clone()),
+                                            ("coredb.io/name".to_string(), namespace.to_string()),
+                                        ]
+                                        .into_iter()
+                                        .collect(),
+                                    ),
+                                    ..Default::default()
+                                }),
+                                spec: PersistentVolumeClaimSpec {
+                                    access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+                                    storage_class_name: Some("gp3-enc".to_string()),
+                                    resources: Some(VolumeResourceRequirements {
+                                        requests: Some(
+                                            [(
+                                                "storage".to_string(),
+                                                Quantity(storage_size.to_string()),
+                                            )]
+                                            .into_iter()
+                                            .collect(),
+                                        ),
+                                        ..Default::default()
+                                    }),
+                                    ..Default::default()
+                                },
+                            }),
+                        }),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }),
+            },
+            backoff_limit: Some(0),
+            ..Default::default()
+        }),
+        status: None,
+    };
+
+    let jobs: Api<Job> = Api::namespaced(kube_client.clone(), namespace);
+    jobs.create(&PostParams::default(), &job)
+        .await
+        .map_err(|e| ErrorInternalServerError(format!("Failed to create backup job: {}", e)))?;
+    Ok(())
+}
+
+/// Checks the current status of a Kubernetes backup Job without polling.
+///
+/// This function queries the Kubernetes API for the Job named `temback-backup-{job_id}` in the given namespace.
+/// It inspects the Job's status and returns:
+/// - `JobStatus::Completed` if the Job succeeded
+/// - `JobStatus::Failed` if the Job failed
+/// - `JobStatus::Processing` if the Job is still running
+/// - `JobStatus::Unknown` if the Job does not exist or status is indeterminate
+///
+/// # Arguments
+/// * `kube_client` - Kubernetes client
+/// * `namespace` - Namespace where the Job is running
+/// * `job_id` - The backup job identifier (UUID)
+///
+/// # Returns
+/// * `JobStatus` - The current status of the Job
+pub async fn get_job_status(kube_client: &KubeClient, namespace: &str, job_id: &str) -> JobStatus {
+    let job_name = format!("temback-backup-{job_id}");
+    tracing::debug!(namespace = %namespace, job_id = %job_id, job_name = %job_name, "Checking Kubernetes Job status");
+    let jobs: Api<K8sJob> = Api::namespaced(kube_client.clone(), namespace);
+
+    let job = match jobs.get(&job_name).await {
+        Ok(job) => job,
+        Err(e) => {
+            tracing::debug!(error = %e, job_name = %job_name, "Job not found or error fetching job");
+            return JobStatus::Unknown;
+        }
+    };
+
+    if let Some(status) = &job.status {
+        tracing::debug!(status = ?status, "Fetched job status struct");
+        if let Some(succeeded) = status.succeeded {
+            tracing::debug!(succeeded = succeeded, "Job succeeded count");
+            if succeeded > 0 {
+                return JobStatus::Completed;
+            }
+        }
+        if let Some(failed) = status.failed {
+            tracing::debug!(failed = failed, "Job failed count");
+            if failed > 0 {
+                return JobStatus::Failed;
+            }
+        }
+    } else {
+        tracing::debug!("Job status is None");
+    }
+    JobStatus::Processing
+}

--- a/dataplane-webserver/src/backups/mod.rs
+++ b/dataplane-webserver/src/backups/mod.rs
@@ -1,5 +1,9 @@
+pub mod coredb;
+pub mod job;
 pub mod s3;
+pub mod temback;
 pub mod types;
+pub use job::create_backup_job;
 
 use crate::{
     backups::{s3::update_backup_status, types::BackupResult},
@@ -8,16 +12,11 @@ use crate::{
 use actix_web::{error::ErrorInternalServerError, Error};
 use aws_sdk_s3::Client as S3Client;
 use controller::apis::coredb_types::CoreDB;
-use k8s_openapi::api::core::v1::{Namespace, Pod};
+use k8s_openapi::api::core::v1::Namespace;
 use kube::{
-    api::{Api, AttachParams, ListParams},
+    api::{Api, ListParams},
     Client as KubeClient,
 };
-use tokio::io::AsyncReadExt;
-
-const TEMBACK_INSTALL_DIR: &str = "/var/lib/postgresql/data";
-const TEMBACK_BINARY: &str = "/var/lib/postgresql/data/temback";
-const TEMBACK_INSTALL_CMD_TEMPLATE: &str = "curl -L https://github.com/tembo-io/temback/releases/download/{version}/temback-{version}-linux-amd64.tar.gz | tar -C {install_dir} --strip-components=1 -zxf - temback-{version}-linux-amd64/temback && chmod +x {install_dir}/temback";
 
 /// Executes a backup task for a specific database instance and updates its status in S3.
 ///
@@ -36,6 +35,7 @@ const TEMBACK_INSTALL_CMD_TEMPLATE: &str = "curl -L https://github.com/tembo-io/
 /// * `bucket_path` - Base path in the bucket
 /// * `namespace` - Kubernetes namespace
 /// * `config` - Application configuration
+/// * `coredb` - CoreDB object
 ///
 /// # Returns
 /// * `Ok(())` if the backup process and metadata updates complete successfully
@@ -51,54 +51,53 @@ pub async fn perform_backup_task(
     bucket_path: String,
     namespace: String,
     config: &Config,
+    coredb: &CoreDB,
 ) -> Result<(), Error> {
     // Log the start of the backup process
     tracing::info!(
         organization_id = %org_id,
         instance_id = %instance_id,
         job_id = %job_id,
-        "Starting database backup"
+        "Starting database backup (via Job)"
     );
 
-    // Perform the actual backup
-    let backup_result =
-        run_backup_on_instance_pod(kube_client, &namespace, &bucket_name, &bucket_path, config)
-            .await?;
+    // Get the storage size from CoreDB
+    let storage_size = coredb::get_storage_size_from_coredb(coredb)?;
+    let temback_image_name = &config.temback_image;
+    let temback_image_version = &config.temback_version;
+    let temback_image = format!("{temback_image_name}:{temback_image_version}");
+    // Create the backup Job
+    create_backup_job(
+        kube_client,
+        &namespace,
+        &job_id,
+        &bucket_name,
+        &bucket_path,
+        &storage_size,
+        &temback_image,
+    )
+    .await?;
 
     // Define the metadata key
     let metadata_key = format!("{bucket_path}/status.json");
 
-    // Update the status based on the backup result
+    // Update the status to processing (Job creation is async)
     update_backup_status(
         client,
         &bucket_name,
         &metadata_key,
-        &backup_result,
+        &BackupResult::Processing,
         &namespace,
     )
     .await?;
 
-    match backup_result {
-        BackupResult::Success => {
-            tracing::info!(
-                organization_id = %org_id,
-                instance_id = %instance_id,
-                job_id = %job_id,
-                "Backup completed successfully"
-            );
-            Ok(())
-        }
-        BackupResult::Failed(error) => {
-            tracing::error!(
-                error = %error,
-                organization_id = %org_id,
-                instance_id = %instance_id,
-                job_id = %job_id,
-                "Backup failed"
-            );
-            Err(ErrorInternalServerError(error))
-        }
-    }
+    tracing::info!(
+        organization_id = %org_id,
+        instance_id = %instance_id,
+        job_id = %job_id,
+        "Backup Job created successfully"
+    );
+    Ok(())
 }
 
 /// Find the Kubernetes namespace for a given organization and instance.
@@ -156,457 +155,4 @@ pub async fn find_instance_namespace(
     );
 
     Ok(namespace)
-}
-
-/// Retrieves and parses the S3 backup path from a CoreDB instance's backup configuration.
-///
-/// This function performs the following steps:
-/// 1. Fetches the CoreDB instance from Kubernetes using the namespace
-/// 2. Extracts the destinationPath from the backup configuration
-/// 3. Parses the S3 URI to separate bucket name and object path
-///
-/// # Arguments
-/// * `kube_client` - Kubernetes client for accessing the CoreDB resource
-/// * `namespace` - Namespace where the CoreDB instance is located
-///
-/// # Returns
-/// * `Ok((String, String))` - Tuple of (bucket_name, object_path)
-/// * `Err(Error)` - If:
-///   - CoreDB instance not found
-///   - Backup configuration missing
-///   - Invalid S3 URI format
-///   - Missing destination path
-///
-/// # Example URI Format
-/// The expected S3 URI format is: `s3://bucket-name/path/to/directory`
-/// For example: `s3://my-bucket/backups/instance-1`
-pub async fn get_backup_path_from_coredb(
-    kube_client: &KubeClient,
-    namespace: &str,
-) -> Result<(String, String), Error> {
-    let coredb_api: Api<CoreDB> = Api::namespaced(kube_client.clone(), namespace);
-    let coredb_name = namespace;
-
-    // Get the CoreDBSpec from the Kubernetes API
-    let coredb = coredb_api
-        .get(coredb_name)
-        .await
-        .map_err(|e| ErrorInternalServerError(format!("Failed to get CoreDB: {}", e)))?;
-
-    // Access the backup configuration from the spec
-    let backup = &coredb.spec.backup;
-
-    // Get the destination path from the backup configuration
-    if let Some(destination_path) = &backup.destinationPath {
-        tracing::info!(
-            namespace = %namespace,
-            destination_path = %destination_path,
-            "Found backup destination path"
-        );
-
-        // Parse the S3 URI (format: s3://bucket-name/path/to/directory)
-        if let Some(path_without_prefix) = destination_path.strip_prefix("s3://") {
-            // Split by the first slash to separate bucket and path
-            if let Some(first_slash_pos) = path_without_prefix.find('/') {
-                let bucket_name = &path_without_prefix[0..first_slash_pos];
-                let object_path = &path_without_prefix[first_slash_pos + 1..];
-
-                tracing::info!(
-                    bucket = %bucket_name,
-                    path = %object_path,
-                    "Parsed S3 URI components"
-                );
-
-                Ok((bucket_name.to_string(), object_path.to_string()))
-            } else {
-                // No path component, just a bucket
-                Ok((path_without_prefix.to_string(), "".to_string()))
-            }
-        } else {
-            Err(ErrorInternalServerError(format!(
-                "Destination path is not a valid S3 URI: {}",
-                destination_path
-            )))
-        }
-    } else {
-        Err(ErrorInternalServerError(
-            "CoreDB backup configuration does not contain a destination path".to_string(),
-        ))
-    }
-}
-
-/// Install temback binary in the specified pod if it doesn't exist or version doesn't match.
-///
-/// # Arguments
-/// * `pods_api` - Kubernetes Pod API
-/// * `pod_name` - Name of the pod to install temback in
-/// * `config` - Application configuration containing temback version
-///
-/// # Returns
-/// * `Ok(())` if installation succeeds or binary already exists with correct version
-/// * `Err(Error)` if installation fails
-async fn install_temback(
-    pods_api: &Api<Pod>,
-    pod_name: &str,
-    config: &Config,
-) -> Result<(), Error> {
-    let attach_params = AttachParams::default()
-        .container("postgres")
-        .stderr(true)
-        .stdout(true)
-        .stdin(false);
-
-    // Try to get current version
-    let version_cmd = vec![TEMBACK_BINARY, "--version"];
-    let mut needs_install = true;
-
-    tracing::debug!(
-        pod = %pod_name,
-        command = ?version_cmd,
-        "Checking temback version"
-    );
-
-    match pods_api
-        .exec(pod_name, version_cmd.clone(), &attach_params)
-        .await
-    {
-        Ok(mut version_output) => {
-            let mut version_stdout = String::new();
-            if let Some(mut stdout) = version_output.stdout() {
-                stdout
-                    .read_to_string(&mut version_stdout)
-                    .await
-                    .map_err(|e| {
-                        ErrorInternalServerError(format!("Failed to read version output: {}", e))
-                    })?;
-            }
-
-            // Parse version from output format (eg: "temback v0.1.1 (0a6689c)")
-            if let Some(version) = version_stdout.split_whitespace().nth(1) {
-                // Ensure config version has 'v' prefix
-                let expected_version = if config.temback_version.starts_with('v') {
-                    config.temback_version.to_string()
-                } else {
-                    format!("v{}", config.temback_version)
-                };
-
-                if version == expected_version {
-                    tracing::debug!(
-                        pod = %pod_name,
-                        version = %version,
-                        "Found matching temback version"
-                    );
-                    needs_install = false;
-                } else {
-                    tracing::info!(
-                        pod = %pod_name,
-                        current_version = %version,
-                        desired_version = %expected_version,
-                        "temback version mismatch, will reinstall"
-                    );
-                }
-            }
-        }
-        Err(e) => {
-            tracing::info!(
-                error = %e,
-                pod = %pod_name,
-                "Failed to get temback version, will install"
-            );
-        }
-    }
-
-    if needs_install {
-        tracing::info!(
-            pod = %pod_name,
-            version = %config.temback_version,
-            "Installing temback..."
-        );
-
-        let install_cmd_str = TEMBACK_INSTALL_CMD_TEMPLATE
-            .replace("{version}", &config.temback_version)
-            .replace("{install_dir}", TEMBACK_INSTALL_DIR);
-        let install_cmd = vec!["sh", "-c", &install_cmd_str];
-
-        tracing::debug!(
-            pod = %pod_name,
-            command = ?install_cmd,
-            "Installing temback"
-        );
-
-        let mut install_output = pods_api
-            .exec(pod_name, install_cmd, &attach_params)
-            .await
-            .map_err(|e| ErrorInternalServerError(format!("Failed to install temback: {}", e)))?;
-
-        // Wait for install to finish by reading all output
-        let mut _out = String::new();
-        if let Some(mut stdout) = install_output.stdout() {
-            stdout.read_to_string(&mut _out).await.ok();
-        }
-        let mut _err = String::new();
-        if let Some(mut stderr) = install_output.stderr() {
-            stderr.read_to_string(&mut _err).await.ok();
-        }
-
-        // Verify the binary exists and check its version
-        let mut verify_result = pods_api
-            .exec(pod_name, version_cmd, &attach_params)
-            .await
-            .map_err(|e| {
-                ErrorInternalServerError(format!("Failed to verify temback installation: {}", e))
-            })?;
-
-        let mut verify_stdout = String::new();
-        if let Some(mut stdout) = verify_result.stdout() {
-            stdout
-                .read_to_string(&mut verify_stdout)
-                .await
-                .map_err(|e| {
-                    ErrorInternalServerError(format!("Failed to read verification output: {}", e))
-                })?;
-        }
-
-        if !verify_stdout.contains(&format!(
-            "v{}",
-            config
-                .temback_version
-                .strip_prefix('v')
-                .unwrap_or(&config.temback_version)
-        )) {
-            return Err(ErrorInternalServerError(format!(
-                "Failed to install correct temback version. Got output: {}",
-                verify_stdout
-            )));
-        }
-
-        tracing::info!(
-            pod = %pod_name,
-            version = %config.temback_version,
-            "Successfully installed temback"
-        );
-    }
-
-    Ok(())
-}
-
-/// Executes a backup using temback in the database pod.
-///
-/// This function performs the following steps:
-/// 1. Finds the primary database pod in the namespace using CloudNativePG labels
-/// 2. Checks for and installs temback binary if not present
-/// 3. Executes temback command to perform backup directly to S3
-///
-/// # Arguments
-/// * `kube_client` - Kubernetes client for pod operations
-/// * `namespace` - Namespace where the database pod is running
-/// * `bucket_name` - S3 bucket to store the backup
-/// * `bucket_path` - Base path in the S3 bucket
-/// * `config` - Application configuration containing temback version
-///
-/// # Returns
-/// * `Ok(BackupResult)` containing Success or Failed with error message
-/// * `Err(Error)` if any step fails catastrophically
-async fn run_backup_on_instance_pod(
-    kube_client: &KubeClient,
-    namespace: &str,
-    bucket_name: &str,
-    bucket_path: &str,
-    config: &Config,
-) -> Result<BackupResult, Error> {
-    // Find the primary database pod
-    let pods_api: Api<Pod> = Api::namespaced(kube_client.clone(), namespace);
-    let label_selector = format!("cnpg.io/cluster={},cnpg.io/instanceRole=primary", namespace);
-    let params = ListParams::default().labels(&label_selector);
-
-    let pods = pods_api
-        .list(&params)
-        .await
-        .map_err(|e| ErrorInternalServerError(format!("Failed to list pods: {}", e)))?;
-
-    if pods.items.is_empty() {
-        return Ok(BackupResult::Failed(
-            "No primary database pod found".to_string(),
-        ));
-    }
-
-    let pod = &pods.items[0];
-    let pod_name = pod
-        .metadata
-        .name
-        .as_ref()
-        .ok_or_else(|| ErrorInternalServerError("Pod has no name"))?;
-
-    tracing::info!(
-        namespace = %namespace,
-        pod = %pod_name,
-        "Found primary database pod for backup"
-    );
-
-    // Install temback if needed
-    if let Err(e) = install_temback(&pods_api, pod_name, config).await {
-        return Ok(BackupResult::Failed(e.to_string()));
-    }
-
-    // Execute temback command in the pod
-    let attach_params = AttachParams::default()
-        .container("postgres")
-        .stderr(true)
-        .stdout(true)
-        .stdin(false);
-
-    let backup_cmd = vec![
-        "/var/lib/postgresql/data/temback",
-        "--name",
-        namespace,
-        "--compress",
-        "--clean",
-        "--cd",
-        "/tmp",
-        "--bucket",
-        &bucket_name,
-        "--dir",
-        &bucket_path,
-    ];
-
-    tracing::debug!(
-        pod = %pod_name,
-        command = ?backup_cmd,
-        "Executing temback backup command"
-    );
-
-    let mut backup_result = pods_api
-        .exec(pod_name, backup_cmd, &attach_params)
-        .await
-        .map_err(|e| {
-            ErrorInternalServerError(format!("Failed to execute backup command: {}", e))
-        })?;
-
-    // Collect both stdout and stderr
-    let mut stdout_msg = String::new();
-    let mut stderr_msg = String::new();
-
-    if let Some(mut stdout) = backup_result.stdout() {
-        stdout.read_to_string(&mut stdout_msg).await.map_err(|e| {
-            ErrorInternalServerError(format!("Failed to read command output: {}", e))
-        })?;
-    }
-
-    if let Some(mut stderr) = backup_result.stderr() {
-        stderr
-            .read_to_string(&mut stderr_msg)
-            .await
-            .map_err(|e| ErrorInternalServerError(format!("Failed to read error output: {}", e)))?;
-    }
-
-    // Log the output regardless of success/failure
-    if !stdout_msg.is_empty() {
-        tracing::info!(
-            output = %stdout_msg,
-            pod = %pod_name,
-            "Backup command stdout"
-        );
-    }
-
-    // If we got any stderr output, consider it a failure
-    if !stderr_msg.is_empty() {
-        tracing::error!(
-            error = %stderr_msg,
-            pod = %pod_name,
-            "Backup command failed with error output"
-        );
-        return Ok(BackupResult::Failed(format!(
-            "Backup command failed: {}",
-            stderr_msg
-        )));
-    }
-
-    tracing::info!(
-        namespace = %namespace,
-        pod = %pod_name,
-        bucket = %bucket_name,
-        bucket_path = %bucket_path,
-        "Successfully ran backup and uploaded to S3"
-    );
-
-    Ok(BackupResult::Success)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use actix_web::error::ErrorInternalServerError;
-
-    fn redact_password_arg(cmd: &[&str]) -> Vec<String> {
-        let mut redacted = cmd.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-        if let Some(pass_index) = redacted.iter().position(|s| s == "--pass") {
-            if pass_index + 1 < redacted.len() {
-                redacted[pass_index + 1] = "[REDACTED]".to_string();
-            }
-        }
-        redacted
-    }
-
-    /// Helper function to test S3 URI parsing logic directly
-    fn parse_s3_uri(uri: &str) -> Result<(String, String), Error> {
-        if let Some(path_without_prefix) = uri.strip_prefix("s3://") {
-            if let Some(first_slash_pos) = path_without_prefix.find('/') {
-                let bucket_name = &path_without_prefix[0..first_slash_pos];
-                let object_path = &path_without_prefix[first_slash_pos + 1..];
-                Ok((bucket_name.to_string(), object_path.to_string()))
-            } else {
-                Ok((path_without_prefix.to_string(), "".to_string()))
-            }
-        } else {
-            Err(ErrorInternalServerError(format!(
-                "Destination path is not a valid S3 URI: {}",
-                uri
-            )))
-        }
-    }
-
-    #[test]
-    fn test_s3_uri_parsing() {
-        // Test case from the example configuration
-        let result =
-            parse_s3_uri("s3://cdb-plat-use1-dev-instance-backups/v2/sorely-adapted-redpoll")
-                .expect("Should parse valid URI");
-        assert_eq!(result.0, "cdb-plat-use1-dev-instance-backups");
-        assert_eq!(result.1, "v2/sorely-adapted-redpoll");
-
-        // Test bucket only
-        let result = parse_s3_uri("s3://my-bucket").expect("Should parse bucket-only URI");
-        assert_eq!(result.0, "my-bucket");
-        assert_eq!(result.1, "");
-
-        // Test multiple path segments
-        let result = parse_s3_uri("s3://bucket/path/to/backup/dir")
-            .expect("Should parse multi-segment path");
-        assert_eq!(result.0, "bucket");
-        assert_eq!(result.1, "path/to/backup/dir");
-
-        // Test invalid URI (no s3:// prefix)
-        assert!(parse_s3_uri("invalid-uri").is_err());
-        assert!(parse_s3_uri("http://wrong-protocol").is_err());
-    }
-
-    #[test]
-    fn test_redact_password_arg() {
-        let cmd = [
-            "/var/lib/postgresql/data/temback",
-            "--name",
-            "testns",
-            "--pass",
-            "supersecret",
-            "--host",
-            "localhost",
-        ];
-        let redacted = redact_password_arg(&cmd);
-        assert_eq!(redacted[3], "--pass");
-        assert_eq!(redacted[4], "[REDACTED]");
-        // Ensure other args are unchanged
-        assert_eq!(redacted[2], "testns");
-        assert_eq!(redacted[5], "--host");
-        assert_eq!(redacted[6], "localhost");
-    }
 }

--- a/dataplane-webserver/src/backups/temback.rs
+++ b/dataplane-webserver/src/backups/temback.rs
@@ -1,0 +1,120 @@
+use crate::config::Config;
+use actix_web::{error::ErrorInternalServerError, Error};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, AttachParams};
+use tokio::io::AsyncReadExt;
+
+const TEMBACK_INSTALL_DIR: &str = "/var/lib/postgresql/data";
+const TEMBACK_INSTALL_CMD_TEMPLATE: &str = "curl -L https://github.com/tembo-io/temback/releases/download/{version}/temback-{version}-linux-amd64.tar.gz | tar -C {install_dir} --strip-components=1 -zxf - temback-{version}-linux-amd64/temback && chmod +x {install_dir}/temback";
+
+/// Install temback binary in the specified pod if it doesn't exist.
+///
+/// # Arguments
+/// * `pods_api` - Kubernetes Pod API
+/// * `pod_name` - Name of the pod to install temback in
+/// * `config` - Application configuration containing temback version
+///
+/// # Returns
+/// * `Ok(())` if installation succeeds or binary already exists
+/// * `Err(Error)` if installation fails
+pub async fn install_temback(
+    pods_api: &Api<Pod>,
+    pod_name: &str,
+    config: &Config,
+) -> Result<(), Error> {
+    let temback_path = format!("{}/temback", TEMBACK_INSTALL_DIR);
+    let check_cmd = vec!["ls", temback_path.as_str()];
+    let attach_params = AttachParams::default()
+        .container("postgres")
+        .stderr(true)
+        .stdout(true)
+        .stdin(false);
+
+    tracing::debug!(
+        pod = %pod_name,
+        command = ?check_cmd,
+        path = %temback_path,
+        "Checking for temback binary"
+    );
+
+    let mut check_output = pods_api
+        .exec(pod_name, check_cmd, &attach_params)
+        .await
+        .map_err(|e| ErrorInternalServerError(format!("Failed to execute temback check: {}", e)))?;
+
+    let mut error_msg = String::new();
+    if let Some(mut stderr) = check_output.stderr() {
+        stderr.read_to_string(&mut error_msg).await.map_err(|e| {
+            ErrorInternalServerError(format!("Failed to read check command error output: {}", e))
+        })?;
+    }
+
+    if !error_msg.is_empty() {
+        tracing::info!(
+            pod = %pod_name,
+            version = %config.temback_version,
+            "temback not found, installing..."
+        );
+
+        let install_cmd_str = TEMBACK_INSTALL_CMD_TEMPLATE
+            .replace("{version}", &config.temback_version)
+            .replace("{install_dir}", TEMBACK_INSTALL_DIR);
+        let install_cmd = vec!["sh", "-c", &install_cmd_str];
+
+        tracing::debug!(
+            pod = %pod_name,
+            command = ?install_cmd,
+            "Installing temback"
+        );
+
+        let mut install_output = pods_api
+            .exec(pod_name, install_cmd, &attach_params)
+            .await
+            .map_err(|e| ErrorInternalServerError(format!("Failed to install temback: {}", e)))?;
+
+        // Wait for install to finish by reading all output
+        let mut _out = String::new();
+        if let Some(mut stdout) = install_output.stdout() {
+            stdout.read_to_string(&mut _out).await.ok();
+        }
+        let mut _err = String::new();
+        if let Some(mut stderr) = install_output.stderr() {
+            stderr.read_to_string(&mut _err).await.ok();
+        }
+
+        // Verify the binary exists after installation
+        let check_cmd = vec!["ls", temback_path.as_str()];
+        let mut verify_result = pods_api
+            .exec(pod_name, check_cmd, &attach_params)
+            .await
+            .map_err(|e| {
+                ErrorInternalServerError(format!("Failed to verify temback installation: {}", e))
+            })?;
+
+        let mut verify_error = String::new();
+        if let Some(mut stderr) = verify_result.stderr() {
+            stderr
+                .read_to_string(&mut verify_error)
+                .await
+                .map_err(|e| {
+                    ErrorInternalServerError(format!(
+                        "Failed to read verification error output: {}",
+                        e
+                    ))
+                })?;
+        }
+
+        if !verify_error.is_empty() {
+            return Err(ErrorInternalServerError(
+                "Failed to install temback: Binary not found after installation".to_string(),
+            ));
+        }
+
+        tracing::info!(
+            pod = %pod_name,
+            "Successfully installed temback"
+        );
+    }
+
+    Ok(())
+}

--- a/dataplane-webserver/src/backups/types.rs
+++ b/dataplane-webserver/src/backups/types.rs
@@ -63,11 +63,36 @@ pub enum BackupStatus {
 ///
 /// # Variants
 /// * `Success` - Backup operation completed successfully
+/// * `Processing` - Backup operation is currently in progress
 /// * `Failed` - Backup operation failed with an error message
 #[derive(Debug)]
 pub enum BackupResult {
     /// Backup operation completed successfully
     Success,
+    /// Backup operation is currently in progress
+    Processing,
     /// Backup operation failed with an error message
     Failed(String),
+}
+
+/// Represents the connection information needed to connect to a database instance for backup.
+#[derive(Debug, Clone)]
+pub struct ConnectionInfo {
+    pub host: String,
+    pub user: String,
+    pub password: String,
+    pub port: String,
+}
+
+/// Represents the status of a Kubernetes Job for backup processing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JobStatus {
+    /// Job is still running
+    Processing,
+    /// Job completed successfully
+    Completed,
+    /// Job failed
+    Failed,
+    /// Job status is unknown or job does not exist
+    Unknown,
 }

--- a/dataplane-webserver/src/config.rs
+++ b/dataplane-webserver/src/config.rs
@@ -7,6 +7,7 @@ pub struct Config {
     pub prometheus_timeout_ms: i32,
     pub backup_bucket_region: String,
     pub backup_uri_timeout: i32,
+    pub temback_image: String,
     pub temback_version: String,
 }
 
@@ -42,7 +43,8 @@ impl Default for Config {
                     300
                 }
             },
-            temback_version: from_env_default("TEMBACK_VERSION", "v0.2.1"),
+            temback_image: from_env_default("TEMBACK_IMAGE", "quay.io/tembo/temback"),
+            temback_version: from_env_default("TEMBACK_VERSION", "v0.3.0"),
         }
     }
 }


### PR DESCRIPTION
* Rework the backup process to create a Kubernetes `Job` and run `temback` to backup to the s3 bucket for the instance.
* Rework fetching metadata and `Job` status from the `GET` route

---

To trigger a backup: 

```bash
curl -X POST "https://api.data-1.use1.cdb-dev.com/api/v1/orgs/{org_id}/instances/{instance_id}/backup" -H 'accept: */*' -H 'Authorization: Bearer $TEMBO_JWT_TOKEN'  -H 'Content-Type: application/json'

{"job_id":"76ffc517-071c-46c6-9d44-c60ccca7861c","status":"processing"}
```
Check status/Get Download

```bash
curl -X GET "https://api.data-1.use1.cdb-dev.com/api/v1/orgs/{org_id}/instances/{instance_id}/backup/76ffc517-071c-46c6-9d44-c60ccca7861c" -H 'accept: */*' -H 'Authorization: Bearer $TEMBO_JWT_TOKEN'  -H 'Content-Type: application/json'

{"status":"completed","job_id":"76ffc517-071c-46c6-9d44-c60ccca7861c","download_url":"{S3 download URL}","expires_at":"2025-05-05T18:44:21.906089893+00:00"}
```


