### PR TITLE
update all api.tembo.io to cloud-api.tembo.io

### DIFF
--- a/cp-client/README.md
+++ b/cp-client/README.md
@@ -1,6 +1,6 @@
-# Rust API client for api.tembo.io
+# Rust API client for cloud-api.tembo.io
 
-Platform API for Tembo Cloud. API documentation is available [here](https://api.tembo.io/swagger-ui/).
+Platform API for Tembo Cloud. API documentation is available [here](https://cloud-api.tembo.io/swagger-ui/).
 
 ## Overview
 

--- a/dataplane-webserver/src/main.rs
+++ b/dataplane-webserver/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> std::io::Result<()> {
             r#"In the case of large or sensitive data, we avoid collecting it into Tembo Cloud. Instead, there is a Tembo Data API for each region, cloud, or private data plane.
             </br>
             </br>
-            To find the Tembo Cloud API, please find it [here](https://api.tembo.io/swagger-ui/).
+            To find the Tembo Cloud API, please find it [here](https://cloud-api.tembo.io/swagger-ui/).
             "#.to_string()
         );
         doc.info.version = "v0.0.1".to_owned();
@@ -85,7 +85,7 @@ async fn main() -> std::io::Result<()> {
             r#"In the case of large or sensitive data, we avoid collecting it into Tembo Cloud. Instead, there is a Tembo Data API for each region, cloud, or private data plane.
             </br>
             </br>
-            To find the Tembo Cloud API, please find it [here](https://api.tembo.io/redoc).
+            To find the Tembo Cloud API, please find it [here](https://cloud-api.tembo.io/redoc).
             "#.to_string()
         );
 

--- a/examples/tembo-api/tembo-api.ipynb
+++ b/examples/tembo-api/tembo-api.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "org_id = \"\"\n",
-    "tembo_prod = \"https://api.tembo.io/api/v1\"\n",
+    "tembo_prod = \"https://cloud-api.tembo.io/api/v1\"\n",
     "token = \"\""
    ]
   },

--- a/tembo-cli/README.md
+++ b/tembo-cli/README.md
@@ -10,14 +10,14 @@ managing, and running Postgres.
 
 Using homebrew
 
-``` sh
+```sh
 brew tap tembo-io/tembo
 brew install tembo-cli
 ```
 
 Using cargo
 
-``` sh
+```sh
 cargo install tembo-cli
 ```
 
@@ -31,7 +31,7 @@ Discover a wide range of commands and subcommands, along with their respective o
 
 Clone this repo and run:
 
-``` sh
+```sh
 cargo install --path .
 ```
 
@@ -39,7 +39,7 @@ If the install path is in your shell path, you can then run `tembo help` and oth
 
 You can run this command to use the local code for any tembo command during development:
 
-``` sh
+```sh
 alias tembo='cargo run --'
 ```
 
@@ -61,7 +61,7 @@ openapi-generator generate -i https://api.data-1.use1.tembo.io/api-docs/openapi.
 
 - Go to `tembodataclient/src/lib.rs` & add following line at the top to disable clippy for the generated code
 
-``` rs
+```rs
 #![allow(clippy::all)]
 ```
 
@@ -72,12 +72,12 @@ Go to `tembo_api_client` directory in your terminal.
 Delete the contents of the directory first and then run following command to re-generate the rust client code for the API.
 
 ```bash
-openapi-generator generate -i https://api.tembo.io/api-docs/openapi.json  -g rust -o . --additional-properties=packageName=tembo_api_client
+openapi-generator generate -i https://cloud-api.tembo.io/api-docs/openapi.json  -g rust -o . --additional-properties=packageName=tembo_api_client
 ```
 
 - Go to `tembo_api_client/src/lib.rs` & add following line at the top to disable clippy for the generated code
 
-``` rs
+```rs
 #![allow(clippy::all)]
 ```
 
@@ -175,7 +175,7 @@ impl FromStr for StackType {
 
 - Add following line towards the end of `tembo_api_client/src/models/mod.rs`
 
-``` rs
+```rs
 pub mod impls;
 ```
 

--- a/tembo-cli/src/cli/context.rs
+++ b/tembo-cli/src/cli/context.rs
@@ -26,7 +26,7 @@ pub const CREDENTIALS_EXAMPLE_TEXT: &str = "version = \"1.0\"
 [[profile]]
 name = 'prod'
 tembo_access_token = 'ACCESS_TOKEN'
-tembo_host = 'https://api.tembo.io'
+tembo_host = 'https://cloud-api.tembo.io'
 tembo_data_host = 'https://api.data-1.use1.tembo.io'
 ";
 
@@ -53,7 +53,7 @@ pub const CREDENTIALS_DEFAULT_TEXT: &str = "version = \"1.0\"
 # name = 'prod'
 # Generate an Access Token either through 'tembo login' or visit 'https://cloud.tembo.io/generate-jwt'
 # tembo_access_token = 'Access token here'
-# tembo_host = 'https://api.tembo.io'
+# tembo_host = 'https://cloud-api.tembo.io'
 # tembo_data_host = 'https://api.data-1.use1.tembo.io'
 ";
 

--- a/tembo-cli/src/cmd/login.rs
+++ b/tembo-cli/src/cmd/login.rs
@@ -87,7 +87,7 @@ pub fn execute(login_cmd: LoginCommand) -> Result<(), anyhow::Error> {
 
 fn url(cmd: Option<&str>) -> Result<String, anyhow::Error> {
     let lifetime = token_lifetime()?;
-    let default_tembo_host = "https://api.tembo.io";
+    let default_tembo_host = "https://cloud-api.tembo.io";
     let modified_tembo_host = cmd.unwrap_or(default_tembo_host);
     let tembo_host = modified_tembo_host.replace("api", "cloud");
     let login_url = tembo_host.clone() + "/cli-success?isCli=true&expiry=" + &lifetime;
@@ -280,7 +280,7 @@ fn append_to_file(file_path: &str, content: String) -> io::Result<()> {
 }
 
 pub fn execute_command(cmd: &LoginCommand, token: &str) -> Result<(), anyhow::Error> {
-    let default_tembo_host = "https://api.tembo.io";
+    let default_tembo_host = "https://cloud-api.tembo.io";
     let default_tembo_data_host = "https://api.data-1.use1.tembo.io";
 
     let tembo_host = cmd

--- a/tembo-cli/tembodataclient/src/apis/secrets_api.rs
+++ b/tembo-cli/tembodataclient/src/apis/secrets_api.rs
@@ -1,7 +1,7 @@
 /*
  * Tembo Data API
  *
- * In the case of large or sensitive data, we avoid collecting it into Tembo Cloud. Instead, there is a Tembo Data API for each region, cloud, or private data plane.             </br>             </br>             To find the Tembo Cloud API, please find it [here](https://api.tembo.io/swagger-ui/).
+ * In the case of large or sensitive data, we avoid collecting it into Tembo Cloud. Instead, there is a Tembo Data API for each region, cloud, or private data plane.             </br>             </br>             To find the Tembo Cloud API, please find it [here](https://cloud-api.tembo.io/swagger-ui/).
  *
  * The version of the OpenAPI document: v0.0.1
  *

--- a/tembo-cli/tests/integration_tests_cloud.rs
+++ b/tembo-cli/tests/integration_tests_cloud.rs
@@ -137,7 +137,7 @@ fn setup_env(instance_name: &String) -> Result<(), Box<dyn Error>> {
 
     replace_vars_in_file(
         tembo_credentials_file_path(),
-        "https://api.tembo.io",
+        "https://cloud-api.tembo.io",
         &get_var("TEMBO_HOST", "https://api.cdb-dev.com")?,
     )?;
 


### PR DESCRIPTION
Update all references in code from `api.tembo.io` to `cloud-api.tembo.io`

- Linear: [TEM-3886](https://linear.app/tembo/issue/TEM-3886/move-tembo-v2-api-to-temboio-domain)