### PR TITLE
when backing up use plain text

### DIFF
--- a/dataplane-webserver/src/backups/job.rs
+++ b/dataplane-webserver/src/backups/job.rs
@@ -64,6 +64,7 @@ pub async fn create_backup_job(
         "$(BUCKET_PATH)",
         "--cd",
         "$(MOUNT_PATH)",
+        "--text",
         "--compress",
         "--clean",
     ];


### PR DESCRIPTION
When we backup the database with `temback` we should use `--text` option to make sure the backup is compatible with all versions of `pg_restore` and all Postgres versions